### PR TITLE
Updated deployment.name to match build.finalName of employee-rostering-webapp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <wildfly.launchdir>${project.basedir}/local/appserver/wildfly-${version.org.wildfly.wildfly-dist}</wildfly.launchdir>
     <wildfly.install.skip>false</wildfly.install.skip>
     <deployment.parent>${project.basedir}/employee-rostering-webapp/target</deployment.parent>
-    <deployment.name>${project.artifactId}-webapp-${project.version}</deployment.name>
+    <deployment.name>optaweb-${project.artifactId}-${project.version}</deployment.name>
     <antrun.skip>false</antrun.skip>
 
     <!-- Maven resource filtering -->


### PR DESCRIPTION
Should we have a property build.finalName in `pom.xml` that is used in the <buildFinalName> element in employee-rostering-webapp's `pom.xml`? (Note: deployment.name must match build.finalName, otherwise you cannot launch the server from maven)