### PR TITLE
PLANNER-1173: Fixed indictment issues

### DIFF
--- a/employee-rostering-gwtui/src/main/java/org/optaweb/employeerostering/gwtui/client/viewport/shiftroster/IconContainer.java
+++ b/employee-rostering-gwtui/src/main/java/org/optaweb/employeerostering/gwtui/client/viewport/shiftroster/IconContainer.java
@@ -16,19 +16,27 @@
 
 package org.optaweb.employeerostering.gwtui.client.viewport.shiftroster;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.inject.Named;
 
+import elemental2.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 
 @Templated
-public class IconContainer {
+public class IconContainer
+        implements
+        IsElement {
 
     @Inject
     @DataField("hard-constraint-broken")
     private IndictmentBadge hardConstraintBroken;
-    
+
     @Inject
     @DataField("medium-constraint-broken")
     private IndictmentBadge mediumConstraintBroken;
@@ -41,12 +49,19 @@ public class IconContainer {
     @DataField("soft-constraint-reward")
     private IndictmentBadge softConstraintReward;
 
+    @Inject
+    @Named("span")
+    private HTMLElement spanFactory;
+
+    private List<HTMLElement> addedIcons;
+
     @PostConstruct
     public void init() {
         hardConstraintBroken.getIcon().classList.add("fa", "fa-ban");
         mediumConstraintBroken.getIcon().classList.add("fa", "fa-times-circle");
         softConstraintPenalty.getIcon().classList.add("pficon", "pficon-warning-triangle-o");
         softConstraintReward.getIcon().classList.add("pficon", "pficon-ok");
+        addedIcons = new ArrayList<>();
     }
 
     public void add(Icon icon, String tooltip) {
@@ -63,6 +78,19 @@ public class IconContainer {
             case SOFT_CONSTRAINT_REWARD:
                 softConstraintReward.addConstraintMatch(tooltip);
                 break;
+            case NONE:
+                HTMLElement newInfoIcon = (HTMLElement) (spanFactory.cloneNode(true));
+                switch (icon) {
+                    case PINNED:
+                        newInfoIcon.classList.add("pinned");
+                        break;
+                    default:
+                        throw new IllegalStateException("Missing case for " + icon.getConstraintMatchCategory().name() + ".");
+                }
+                newInfoIcon.title = tooltip;
+                getElement().insertBefore(newInfoIcon, hardConstraintBroken.getElement());
+                addedIcons.add(newInfoIcon);
+                break;
             default:
                 throw new IllegalStateException("Missing case for " + icon.getConstraintMatchCategory().name() + ".");
         }
@@ -73,6 +101,7 @@ public class IconContainer {
         mediumConstraintBroken.clear();
         softConstraintPenalty.clear();
         softConstraintReward.clear();
+        addedIcons.forEach(e -> e.remove());
     }
 
     public static enum Icon {
@@ -82,7 +111,8 @@ public class IconContainer {
         UNDESIRED_TIMESLOT_FOR_EMPLOYEE_PENALTY(ConstraintMatchCategory.SOFT_CONSTRAINT_PENALTY),
         ROTATION_VIOLATION_PENALTY(ConstraintMatchCategory.SOFT_CONSTRAINT_PENALTY),
         UNASSIGNED_SHIFT_PENALTY(ConstraintMatchCategory.MEDIUM_CONSTRAINT_BROKEN),
-        REQUIRED_SKILL_VIOLATION(ConstraintMatchCategory.HARD_CONSTRAINT_BROKEN);
+        REQUIRED_SKILL_VIOLATION(ConstraintMatchCategory.HARD_CONSTRAINT_BROKEN),
+        PINNED(ConstraintMatchCategory.NONE);
 
         private ConstraintMatchCategory constraintMatchCategory;
 
@@ -99,6 +129,7 @@ public class IconContainer {
         HARD_CONSTRAINT_BROKEN,
         MEDIUM_CONSTRAINT_BROKEN,
         SOFT_CONSTRAINT_PENALTY,
-        SOFT_CONSTRAINT_REWARD;
+        SOFT_CONSTRAINT_REWARD,
+        NONE;
     }
 }

--- a/employee-rostering-gwtui/src/main/resources/org/optaweb/employeerostering/gwtui/client/viewport/shiftroster/IconContainer.css
+++ b/employee-rostering-gwtui/src/main/resources/org/optaweb/employeerostering/gwtui/client/viewport/shiftroster/IconContainer.css
@@ -1,14 +1,20 @@
 .icon-container {
     display: flex;
     flex-shrink: 0;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     flex-grow: 1;
     flex-direction: row;
-    margin-top: -10px;
+    height: 100%;
+    margin-bottom: -50px;
+    padding-bottom: 50px;
+    overflow-y: hidden;
+    overflow-x: visible;
 }
 
 .indictment-badge {
     height: min-content;
+    margin-left: 0;
+    margin-right: 5px;
     font-size: 9px;
     min-width: 30px;
 }

--- a/employee-rostering-gwtui/src/main/resources/org/optaweb/employeerostering/gwtui/public/viewport.less
+++ b/employee-rostering-gwtui/src/main/resources/org/optaweb/employeerostering/gwtui/public/viewport.less
@@ -84,6 +84,50 @@
     height: ~"calc(100% - 2px)";
 }
 
+.score {
+	animation-name: score-highlight;
+	animation-play-state: paused;
+	animation-duration: 100s;
+}
+
+/* TODO: Get UX input on colors */
+@keyframes score-highlight {
+  /* Negative Hard */
+  0% {
+    background-color: rgba(139, 0, 0, 0.49);
+  }
+  
+  /* Negative Medium */ 
+  15% {
+    background-color: rgba(245, 193, 46, 0.49);
+  }
+  
+  /* Negative Soft */
+  30% {
+    background-color: rgba(209, 209, 209, 0.49);
+  }
+  
+  /* Zero Score */
+  50% {
+    background-color: rgba(207, 231, 205, 0.49);
+  }
+  
+  /* Positive Soft */
+  70% {
+    background-color: rgba(63, 156, 53, 0.49);
+  }
+  
+  /* Positive Medium */
+  85% {
+    background-color: rgba(0, 185, 228, 0.49);
+  }
+  
+  /* Positive Hard */
+  100% {
+     background-color: rgba(112, 63, 236, 0.49);
+  }
+} 
+
 .spanning-blob {
 	position: absolute;
 	width: 100%;
@@ -135,6 +179,10 @@
 .pinned:before {
 	font-family: FontAwesome;
     content: "\f08d"; /*Pin*/
+}
+
+.pinned {
+    margin-right: 5px;
 }
 
 .ui-resizable { position: relative;}


### PR DESCRIPTION
For Icons, if it overflows, you can scroll to see the rest (no scrollbar is shown) (we might be able to indicate this using a shadow). I added a colour scheme: -Hard -> red, -Medium -> yellow, -Soft -> gray, ZERO -> light green, +Soft -> green, +Medium (impossible currently) -> light blue, +Hard (impossible currently) -> purple (modifiable via CSS). The shades get more/less strong depending on how positive/negative the scores are, up to a limit, linearly. 