### PR TITLE
Increase cargo deployment timeout

### DIFF
--- a/optashift-employee-rostering-webapp/pom.xml
+++ b/optashift-employee-rostering-webapp/pom.xml
@@ -97,7 +97,7 @@
                 <artifactId>${project.artifactId}</artifactId>
                 <type>war</type>
                 <pingURL>${application.url}</pingURL>
-                <pingTimeout>30000</pingTimeout>
+                <pingTimeout>120000</pingTimeout>
               </deployable>
             </deployables>
             <configuration>


### PR DESCRIPTION
Increasing to two minutes which should satisfy the kieAllBuild.