### PR TITLE
PLANNER-1221: To decrease deployment time on MySQL, allowed user to select generation stategy

### DIFF
--- a/employee-rostering-docs/src/main/asciidoc/Introduction/SystemProperties/SystemProperties-section.adoc
+++ b/employee-rostering-docs/src/main/asciidoc/Introduction/SystemProperties/SystemProperties-section.adoc
@@ -16,3 +16,4 @@ The OpenShift docker image also supports these parameters:
 * *org.optaweb.employeerostering.persistence.datasource*
 * *org.optaweb.employeerostering.persistence.dialect*
 * *org.optaweb.employeerostering.persistence.hbm2ddl.auto*
+* *org.optaweb.employeerostering.persistence.id.generator*

--- a/employee-rostering-server/src/main/filtered-resources/META-INF/orm.xml
+++ b/employee-rostering-server/src/main/filtered-resources/META-INF/orm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ 
+<entity-mappings
+    xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm orm_2_1.xsd"
+    version="2.1"
+        >
+    <entity class="org.optaweb.employeerostering.shared.tenant.Tenant">
+        <attributes>
+            <id name="id">
+                <generated-value strategy="${org.optaweb.employeerostering.persistence.id.generator}"/>
+            </id>
+        </attributes>
+    </entity>
+    <mapped-superclass class="org.optaweb.employeerostering.shared.common.AbstractPersistable">
+        <attributes>
+            <id name="id">
+                <generated-value strategy="${org.optaweb.employeerostering.persistence.id.generator}"/>
+            </id>
+        </attributes>
+    </mapped-superclass>
+</entity-mappings>

--- a/employee-rostering-server/src/main/filtered-resources/META-INF/persistence.xml
+++ b/employee-rostering-server/src/main/filtered-resources/META-INF/persistence.xml
@@ -4,6 +4,7 @@
   <persistence-unit name="optaweb-employee-rostering-persistence-unit" transaction-type="JTA">
     <description>OptaWeb Employee Rostering Persistence Unit</description>
     <jta-data-source>${org.optaweb.employeerostering.persistence.datasource}</jta-data-source>
+    <mapping-file>META-INF/orm.xml</mapping-file>
     <class>org.optaweb.employeerostering.shared.skill.Skill</class>
     <class>org.optaweb.employeerostering.shared.spot.Spot</class>
     <class>org.optaweb.employeerostering.shared.employee.Employee</class>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <org.optaweb.employeerostering.persistence.datasource>java:jboss/datasources/ExampleDS</org.optaweb.employeerostering.persistence.datasource>
     <org.optaweb.employeerostering.persistence.dialect>org.hibernate.dialect.H2Dialect</org.optaweb.employeerostering.persistence.dialect>
     <org.optaweb.employeerostering.persistence.hbm2ddl.auto>create</org.optaweb.employeerostering.persistence.hbm2ddl.auto>
+    <org.optaweb.employeerostering.persistence.id.generator>AUTO</org.optaweb.employeerostering.persistence.id.generator>
 
     <!--
       It's recommended, but not required to align the versions as much as possible with
@@ -488,6 +489,7 @@
         <org.optaweb.employeerostering.persistence.datasource>${dollarSign}{org.optaweb.employeerostering.persistence.datasource:java:jboss/datasources/ExampleDS}</org.optaweb.employeerostering.persistence.datasource>
         <org.optaweb.employeerostering.persistence.dialect>${dollarSign}{org.optaweb.employeerostering.persistence.dialect:org.hibernate.dialect.H2Dialect}</org.optaweb.employeerostering.persistence.dialect>
         <org.optaweb.employeerostering.persistence.hbm2ddl.auto>${dollarSign}{org.optaweb.employeerostering.persistence.hbm2ddl.auto:update}</org.optaweb.employeerostering.persistence.hbm2ddl.auto>
+        <org.optaweb.employeerostering.persistence.id.generator>${dollarSign}{org.optaweb.employeerostering.persistence.id.generator:AUTO}</org.optaweb.employeerostering.persistence.id.generator>
       </properties>
     </profile>
 


### PR DESCRIPTION
Hibernate 5 use TABLE id generation for MySQL since it doesn't support sequences. This is very slow,
making it take longer than 300s to generate the example data and start the application. Instead, it
should use IDENTITY, which allows it to generate all the example data in 75s (boot takes 122s in total).

By default, org.optaweb.employeerostering.persistence.id.generator has value AUTO.

Depends on #188, since MySQL have the same warnings