### PR TITLE
BXMSPROD-38: upgraded com.fasterxml.jackson to 2.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
       https://github.com/jboss-integration/jboss-integration-platform-bom/blob/master/pom.xml
     -->
     <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
-    <version.com.fasterxml.jackson>2.8.8</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.8.11</version.com.fasterxml.jackson>
     <version.com.github.nmorel.gwtjackson.restprocessor>0.4.1</version.com.github.nmorel.gwtjackson.restprocessor>
     <version.com.github.nmorel.gwtjackson>0.14.2</version.com.github.nmorel.gwtjackson>
     <version.com.google.gwt>2.8.2</version.com.google.gwt>


### PR DESCRIPTION
DON'T MERGE before https://github.com/jboss-integration/jboss-integration-platform-bom/pull/424 was merged and jboss-ip-bpm 8.2.0.Final was released and kie-reps updated