### PR TITLE
upgraded version com.fastewrxml.jackson to align to EAP 7.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       https://github.com/jboss-integration/jboss-integration-platform-bom/blob/master/pom.xml
     -->
     <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
-    <version.com.fasterxml.jackson>2.8.10</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
     <version.com.github.nmorel.gwtjackson.restprocessor>0.4.1</version.com.github.nmorel.gwtjackson.restprocessor>
     <version.com.github.nmorel.gwtjackson>0.14.2</version.com.github.nmorel.gwtjackson>
     <version.com.google.gwt>2.8.2</version.com.google.gwt>


### PR DESCRIPTION
to align to JBEAP 7.2 we have to align to com.fasterxml.jackson 2.9.5.
this was tested with this version - the build was successful and no test failed.