### PR TITLE
Use latest version of cargo-maven2-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <version.org.webjars.momentjs>2.22.2</version.org.webjars.momentjs>
     <version.org.wildfly-plugins.wildfly-maven-plugin>1.2.0.Final</version.org.wildfly-plugins.wildfly-maven-plugin>
     <version.org.wildfly.wildfly-dist>11.0.0.Final</version.org.wildfly.wildfly-dist>
-    <version.org.codehaus.cargo.cargo-maven2-plugin>1.6.5</version.org.codehaus.cargo.cargo-maven2-plugin>
+    <version.org.codehaus.cargo.cargo-maven2-plugin>1.6.11</version.org.codehaus.cargo.cargo-maven2-plugin>
     <version.wildfly>11.0.0.Final</version.wildfly>
   </properties>
 


### PR DESCRIPTION
Let's keep the cargo version used throughout the kiegroup repos build consistent.
This is related to https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/854

For more context:
At the moment there are 2 outdated versions of cargo-maven2-plugin used in our [daily build](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/dailyBuild/job/kieAllBuild-master/) We need to upgrade to latest version of the plugin to be able to run tests with wildfly14 that community is upgrading to.