### PR TITLE
PLANNER-1358: Align versions with kie-parent and jboss-ip-bom

### DIFF
--- a/employee-rostering-benchmark/pom.xml
+++ b/employee-rostering-benchmark/pom.xml
@@ -30,52 +30,28 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-benchmark</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- Persistence -->
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.mail</groupId>
-          <artifactId>javax.mail</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate.javax.persistence</groupId>
-          <artifactId>hibernate-jpa-2.1-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.jboss.spec.javax.transaction</groupId>
+      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate.javax.persistence</groupId>
-          <artifactId>hibernate-jpa-2.1-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <!-- Logging -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/employee-rostering-gwtui/pom.xml
+++ b/employee-rostering-gwtui/pom.xml
@@ -15,7 +15,6 @@
   <name>Employee Rostering as a Service GWT UI</name>
 
   <properties>
-    <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
   </properties>
 
@@ -47,6 +46,19 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Java EE APIs -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
@@ -54,6 +66,10 @@
     <dependency>
       <groupId>org.optaweb.employeerostering</groupId>
       <artifactId>employee-rostering-shared</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-project-datamodel-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>
@@ -163,12 +179,6 @@
     <dependency><!-- TODO Remove me, we don't use JPA on the client, but removing this gives blank screen at runtime -->
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-jpa-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate.javax.persistence</groupId>
-          <artifactId>hibernate-jpa-2.1-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
@@ -189,12 +199,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.elemental2</groupId>
-          <artifactId>elemental2-dom</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <!-- Only used for EmbeddedWildFlyLauncher during GWT Super Dev Mode -->
@@ -225,6 +229,44 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>ban-duplicated-classes</id>
+              <configuration>
+                <rules>
+                  <banDuplicateClasses>
+                    <dependencies combine.children="append">
+                      <!-- errai-jpa-client contains GWT-friendly implementation of JPA2 and has a compile dependency
+                      on org.hibernate.javax.persistence:hibernate-jpa-2.1-api so they have many duplicate classes
+                      (e.g. javax.persistence.Entity). On the other hand, hibernate-jpa-2.1-api contains some extra
+                      classes that errai-jpa-client doesn't have. If we exclude hibernate-jpa-2.1-api
+                      from errai-jpa-client, we get:
+                      [main] ERROR org.jboss.errai.config.rebind.AsyncGenerators - Generator failed to launch
+                      java.lang.NoClassDefFoundError: javax/persistence/spi/PersistenceUnitInfo
+                      The best approach seems to be to keep hibernate-jpa-2.1-api and disable Enforcer.
+                      -->
+                      <dependency>
+                        <groupId>org.jboss.errai</groupId>
+                        <artifactId>errai-jpa-client</artifactId>
+                        <type>jar</type>
+                        <ignoreClasses>
+                          <ignoreClass>javax.persistence.*</ignoreClass>
+                        </ignoreClasses>
+                      </dependency>
+                    </dependencies>
+                  </banDuplicateClasses>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/employee-rostering-gwtui/pom.xml
+++ b/employee-rostering-gwtui/pom.xml
@@ -14,25 +14,6 @@
 
   <name>Employee Rostering as a Service GWT UI</name>
 
-  <properties>
-    <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.jsinterop</groupId>
-        <artifactId>base</artifactId>
-        <version>${version.com.google.jsinterop.base}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.elemental2</groupId>
-        <artifactId>elemental2-core</artifactId>
-        <version>${version.com.google.elemental2}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <!-- gwt-dev must be first so the correct JDT ECJ version is on GWT's compiler's classpath -->
     <dependency>

--- a/employee-rostering-restclient/pom.xml
+++ b/employee-rostering-restclient/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/employee-rostering-server/pom.xml
+++ b/employee-rostering-server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -28,41 +28,71 @@
   </build>
 
   <dependencies>
+    <!-- Java EE APIs -->
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ejb</groupId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.interceptor</groupId>
+      <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.transaction</groupId>
+      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.optaweb.employeerostering</groupId>
       <artifactId>employee-rostering-shared</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.mail</groupId>
-          <artifactId>javax.mail</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
     </dependency>
-	<dependency>
-	  <groupId>com.fasterxml.jackson.core</groupId>
-	  <artifactId>jackson-databind</artifactId>
-	</dependency>
-	<dependency>
-	  <groupId>com.fasterxml.jackson.datatype</groupId>
-	  <artifactId>jackson-datatype-jsr310</artifactId>
-	</dependency>
-	<dependency>
-	  <groupId>org.apache.commons</groupId>
-	  <artifactId>commons-lang3</artifactId>
-	</dependency>
-	<dependency> 
-	  <groupId>org.optaplanner</groupId>
-	  <artifactId>optaplanner-persistence-jackson</artifactId>
-	</dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-jackson</artifactId>
+    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/employee-rostering-shared/pom.xml
+++ b/employee-rostering-shared/pom.xml
@@ -15,17 +15,23 @@
   <name>Employee Rostering as a Service Shared</name>
 
   <dependencies>
+    <!-- Java EE APIs -->
     <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.mail</groupId>
-          <artifactId>javax.mail</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- GWT -->
     <dependency>
       <groupId>com.github.nmorel.gwtjackson</groupId>
       <artifactId>gwt-jackson-rest-processor</artifactId>
@@ -46,12 +52,6 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.validation</groupId>
-          <artifactId>validation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.nmorel.gwtjackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <!-- Use JBoss parent so all maven-plugins have a decent base version. -->
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
     <version>7.16.0-SNAPSHOT</version>
-    <relativePath/>
   </parent>
 
   <groupId>org.optaweb.employeerostering</groupId>
@@ -99,18 +97,6 @@
     <module>employee-rostering-distribution</module>
   </modules>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
   <dependencyManagement>
     <dependencies>
       <!-- Internal -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <inceptionYear>2017</inceptionYear>
 
   <repositories>
-    <!-- TODO remove this repository when we no longer use SNAPSHOT dependencies -->
+    <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
     <repository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
@@ -39,9 +39,6 @@
   </repositories>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <wildfly.parent>${project.basedir}/local/appserver</wildfly.parent>
     <wildfly.home>${wildfly.parent}/wildfly-${version.org.wildfly}</wildfly.home>
     <wildfly.launchdir>${project.basedir}/local/appserver/wildfly-${version.org.wildfly}</wildfly.launchdir>
@@ -56,28 +53,14 @@
     <org.optaweb.employeerostering.persistence.hbm2ddl.auto>create</org.optaweb.employeerostering.persistence.hbm2ddl.auto>
     <org.optaweb.employeerostering.persistence.id.generator>AUTO</org.optaweb.employeerostering.persistence.id.generator>
 
-    <!--
-      It's recommended, but not required to align the versions as much as possible with
-      https://github.com/jboss-integration/jboss-integration-platform-bom/blob/master/pom.xml
-    -->
-    <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
-    <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
     <version.com.github.nmorel.gwtjackson.restprocessor>0.4.1</version.com.github.nmorel.gwtjackson.restprocessor>
     <version.com.github.nmorel.gwtjackson>0.14.2</version.com.github.nmorel.gwtjackson>
-    <version.com.google.gwt>2.8.2</version.com.google.gwt>
-    <version.io.swagger>1.5.15</version.io.swagger>
-    <version.net.ltgt.gwt.maven.gwt-maven-plugin>1.0-rc-9</version.net.ltgt.gwt.maven.gwt-maven-plugin>
+    <!-- TODO update gwt-maven-plugin version in kie-parent and then remove this override -->
+    <version.net.ltgt.gwt.maven>1.0-rc-9</version.net.ltgt.gwt.maven>
     <version.org.gwtbootstrap3>0.9.4</version.org.gwtbootstrap3>
-    <version.org.jboss.errai>4.3.3.Final</version.org.jboss.errai>
-    <version.org.optaplanner>${project.version}</version.org.optaplanner>
-    <version.org.kie.soup>${project.version}</version.org.kie.soup>
-    <version.org.slf4j>1.7.25</version.org.slf4j>
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.Eonasdan-bootstrap-datetimepicker>4.17.47</version.org.webjars.Eonasdan-bootstrap-datetimepicker>
     <version.org.webjars.momentjs>2.22.2</version.org.webjars.momentjs>
-    <version.org.wildfly>14.0.1.Final</version.org.wildfly>
-    <version.org.codehaus.cargo.cargo-maven2-plugin>1.7.1</version.org.codehaus.cargo.cargo-maven2-plugin>
-
     <!-- gwtmockito uses a different version of mockito than kie-parent, so we need to override the mockito version,
          kie-parent manages version 1.x -->
     <version.org.mockito>2.12.0</version.org.mockito>
@@ -146,7 +129,7 @@
         <version>${project.version}</version>
       </dependency>
 
-      <!-- JEE -->
+      <!-- BOMs -->
       <dependency>
         <groupId>org.wildfly.bom</groupId>
         <artifactId>wildfly-javaee8</artifactId>
@@ -155,13 +138,30 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <groupId>org.jboss.errai.bom</groupId>
+        <artifactId>errai-internal-bom</artifactId>
+        <version>${version.org.jboss.errai}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-bom</artifactId>
+        <type>pom</type>
+        <scope>import</scope>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-bom</artifactId>
+        <type>pom</type>
+        <version>${version.org.kie}</version>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
+        <artifactId>jackson-annotations</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
       </dependency>
       <dependency>
@@ -169,54 +169,8 @@
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
       </dependency>
-      <!-- KIE -->
-      <dependency>
-        <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.optaplanner}</version>
-        <scope>import</scope>
-      </dependency>
-      <!-- kie-soup-bom -->
-      <dependency>
-        <groupId>org.kie.soup</groupId>
-        <artifactId>kie-soup-bom</artifactId>
-        <type>pom</type>
-        <scope>import</scope>
-        <version>${version.org.kie.soup}</version>
-      </dependency>
-      <!-- Logging -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${version.org.slf4j}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${version.ch.qos.logback}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${version.org.slf4j}</version>
-      </dependency>
 
       <!-- GWT -->
-      <dependency>
-        <groupId>com.google.gwt</groupId>
-        <artifactId>gwt</artifactId>
-        <version>${version.com.google.gwt}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.errai.bom</groupId>
-        <artifactId>errai-bom</artifactId>
-        <version>${version.org.jboss.errai}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>com.github.nmorel.gwtjackson</groupId>
         <artifactId>gwt-jackson</artifactId>
@@ -231,27 +185,6 @@
         <groupId>com.github.nmorel.gwtjackson</groupId>
         <artifactId>gwt-jackson-rest-api</artifactId>
         <version>${version.com.github.nmorel.gwtjackson.restprocessor}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.gwtbootstrap3</groupId>
-        <artifactId>gwtbootstrap3</artifactId>
-        <version>${version.org.gwtbootstrap3}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.gwtbootstrap3</groupId>
-        <artifactId>gwtbootstrap3-extras</artifactId>
-        <version>${version.org.gwtbootstrap3}</version>
-      </dependency>
-      <!-- Swagger -->
-      <dependency>
-        <groupId>io.swagger</groupId>
-        <artifactId>swagger-jaxrs</artifactId>
-        <version>${version.io.swagger}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.swagger</groupId>
-        <artifactId>swagger-annotations</artifactId>
-        <version>${version.io.swagger}</version>
       </dependency>
       <!-- byte-buddy is managed in kie-parent and we need to keep the same version mockito-core defines -->
       <dependency>
@@ -352,7 +285,7 @@
         <plugin>
           <groupId>net.ltgt.gwt.maven</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>${version.net.ltgt.gwt.maven.gwt-maven-plugin}</version>
+          <version>${version.net.ltgt.gwt.maven}</version>
           <extensions>true</extensions>
           <configuration>
             <style>PRETTY</style>
@@ -379,26 +312,6 @@
               <errai.dev.context>optaweb-employee-rostering</errai.dev.context>
             </systemProperties>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-war-plugin</artifactId>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-        </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.cargo</groupId>
-          <artifactId>cargo-maven2-plugin</artifactId>
-          <version>${version.org.codehaus.cargo.cargo-maven2-plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 
     <version.com.github.nmorel.gwtjackson.restprocessor>0.4.1</version.com.github.nmorel.gwtjackson.restprocessor>
     <version.com.github.nmorel.gwtjackson>0.14.2</version.com.github.nmorel.gwtjackson>
+    <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
     <!-- TODO update gwt-maven-plugin version in kie-parent and then remove this override -->
     <version.net.ltgt.gwt.maven>1.0-rc-9</version.net.ltgt.gwt.maven>
     <version.org.gwtbootstrap3>0.9.4</version.org.gwtbootstrap3>
@@ -185,6 +186,16 @@
         <groupId>com.github.nmorel.gwtjackson</groupId>
         <artifactId>gwt-jackson-rest-api</artifactId>
         <version>${version.com.github.nmorel.gwtjackson.restprocessor}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.jsinterop</groupId>
+        <artifactId>base</artifactId>
+        <version>${version.com.google.jsinterop.base}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.elemental2</groupId>
+        <artifactId>elemental2-core</artifactId>
+        <version>${version.com.google.elemental2}</version>
       </dependency>
       <!-- byte-buddy is managed in kie-parent and we need to keep the same version mockito-core defines -->
       <dependency>


### PR DESCRIPTION
## First commit (clean up)

Improvements in POMs after adopting `kie-parent` in #210. For the most part it replaces `javax.javaee-api` with JBoss Spec APIs taken from https://github.com/jboss/jboss-javaee-specs/blob/master/pom.xml#L91.

Part of this commit fixes a GWT compilation classpath problem described in https://github.com/kiegroup/optaweb-employee-rostering/pull/210#issuecomment-439114090. I originally thought it breaks SuperDevMode but it was a local issue that I resolved by `rm -r /tmp`.

## Following commits (version alignment)

Adresses https://issues.jboss.org/browse/PLANNER-1358.