### PR TITLE
[PLANNER-1292] Provide code quality metrics by sonarcloud.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /local
 
 # Eclipse, Netbeans and IntelliJ files
-/.*
+/.idea
 !.gitignore
 !.gitattributes
 /nbproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,14 @@ language: java
 sudo: false
 install: true
 
-addons:
-  sonarcloud:
-    organization: "kiegroup"
-    token:
-      secure: "89a1d7699b3d752aa91e5c58a6e4338be811fcdb"
-
 jdk:
 - oraclejdk8
-
 script:
-# JaCoCo is used to have code coverage, the agent has to be activated
-- mvn clean install -Prun-code-coverage
-- mvn jacoco:merge sonar:sonar -Preport-code-coverage
-
+- mvn --quiet clean install -Prun-code-coverage
+- mvn --quiet jacoco:report jacoco:merge sonar:sonar -Preport-code-coverage -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=kiegroup -Dsonar.login=$SONARCLOUD_TOKEN -Dsonar.projectKey=optaweb-employee-rostering
 cache:
   directories:
-  - '$HOME/.m2/repository'
-  - '$HOME/.sonar/cache'
+  - "$HOME/.m2/repository"
+  - "$HOME/.sonar/cache"
+after_failure:
+- cat $TRAVIS_BUILD_DIR/employee-rostering-webapp/target/configurations/cargo-profile/profile-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: java
+sudo: false
+install: true
+
+addons:
+  sonarcloud:
+    organization: "kiegroup"
+    token:
+      secure: "89a1d7699b3d752aa91e5c58a6e4338be811fcdb"
+
+jdk:
+- oraclejdk8
+
+script:
+# JaCoCo is used to have code coverage, the agent has to be activated
+- mvn clean install -Prun-code-coverage
+- mvn jacoco:merge sonar:sonar -Preport-code-coverage
+
+cache:
+  directories:
+  - '$HOME/.m2/repository'
+  - '$HOME/.sonar/cache'

--- a/employee-rostering-gwtui/pom.xml
+++ b/employee-rostering-gwtui/pom.xml
@@ -227,25 +227,22 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>net.ltgt.gwt.maven</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
-        <configuration>
-          <moduleName>org.optaweb.employeerostering.gwtui.WorkerRosteringWebapp</moduleName>
-        </configuration>
+        <artifactId>maven-surefire-plugin</artifactId>
         <executions>
           <execution>
             <goals>
               <goal>test</goal>
             </goals>
-            <configuration>
-              <includes>
-                <include>**/*Test.java</include>
-              </includes>
-            </configuration>
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>net.ltgt.gwt.maven</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <configuration>
+          <moduleName>org.optaweb.employeerostering.gwtui.WorkerRosteringWebapp</moduleName>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/employee-rostering-webapp/pom.xml
+++ b/employee-rostering-webapp/pom.xml
@@ -108,6 +108,10 @@
               <containerId>${cargo.container.id}</containerId>
               <timeout>600000</timeout>
               <output>${cargo.container.log.file}</output>
+              <systemProperties>
+                <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                <java.net.preferIPv4Addresses>true</java.net.preferIPv4Addresses>
+              </systemProperties>
             </container>
             <deployables>
               <deployable>

--- a/employee-rostering-webapp/pom.xml
+++ b/employee-rostering-webapp/pom.xml
@@ -108,10 +108,6 @@
               <containerId>${cargo.container.id}</containerId>
               <timeout>600000</timeout>
               <output>${cargo.container.log.file}</output>
-              <systemProperties>
-                <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                <java.net.preferIPv4Addresses>true</java.net.preferIPv4Addresses>
-              </systemProperties>
             </container>
             <deployables>
               <deployable>
@@ -265,6 +261,5 @@
         <cargo.goal>run</cargo.goal>
       </properties>
     </profile>
-
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <version.com.github.nmorel.gwtjackson>0.14.2</version.com.github.nmorel.gwtjackson>
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.io.swagger>1.5.15</version.io.swagger>
+    <version.jacoco.plugin>0.8.2</version.jacoco.plugin>
     <version.net.ltgt.gwt.maven.gwt-maven-plugin>1.0-rc-9</version.net.ltgt.gwt.maven.gwt-maven-plugin>
     <version.org.gwtbootstrap3>0.9.4</version.org.gwtbootstrap3>
     <version.org.jboss.errai>4.3.3.Final</version.org.jboss.errai>
@@ -79,6 +80,12 @@
     <version.org.webjars.momentjs>2.22.2</version.org.webjars.momentjs>
     <version.org.wildfly>14.0.1.Final</version.org.wildfly>
     <version.org.codehaus.cargo.cargo-maven2-plugin>1.6.11</version.org.codehaus.cargo.cargo-maven2-plugin>
+
+    <jacoco.agent.line/>
+    <surefire.argLine>
+      -Dfile.encoding=${project.build.sourceEncoding}
+      ${jacoco.agent.line}
+    </surefire.argLine>
     <!-- gwtmockito uses a different version of mockito than kie-parent, so we need to override the mockito version,
          kie-parent manages version 1.x -->
     <version.org.mockito>2.12.0</version.org.mockito>
@@ -500,6 +507,85 @@
       <properties>
         <antrun.skip>true</antrun.skip>
       </properties>
+    </profile>
+
+    <profile>
+      <id>run-code-coverage</id>
+      <properties>
+        <jacoco.exec.file>${project.build.directory}/jacoco.exec</jacoco.exec.file>
+        <jacoco.agent.line>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${version.jacoco.plugin}/org.jacoco.agent-${version.jacoco.plugin}-runtime.jar=destfile=${jacoco.exec.file},append=true,excludes=*Lexer</jacoco.agent.line>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.jacoco</groupId>
+          <artifactId>org.jacoco.agent</artifactId>
+          <version>${version.jacoco.plugin}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <configuration>
+                  <properties>
+                    <cargo.start.jvmargs>${jacoco.agent.line}</cargo.start.jvmargs>
+                  </properties>
+                </configuration>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>net.ltgt.gwt.maven</groupId>
+              <artifactId>gwt-maven-plugin</artifactId>
+              <configuration>
+                <skipCompilation>true</skipCompilation>
+              </configuration>
+            </plugin>
+            <plugin>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <argLine>${surefire.argLine}</argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <!--
+        For automated run, see travis.yml.
+        To report coverage data manually, run "mvn jacoco:merge sonar:sonar" -Preport-code-coverage
+      -->
+      <id>report-code-coverage</id>
+      <properties>
+        <jacoco.master.exec.file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</jacoco.master.exec.file>
+        <sonar.jacoco.reportPaths>${jacoco.master.exec.file}</sonar.jacoco.reportPaths>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.jacoco</groupId>
+              <artifactId>jacoco-maven-plugin</artifactId>
+              <version>${version.jacoco.plugin}</version>
+              <configuration>
+                <fileSets>
+                  <fileSet>
+                    <directory>${project.build.directory}</directory>
+                    <includes>
+                      <include>*.exec</include>
+                    </includes>
+                  </fileSet>
+                </fileSets>
+                <destFile>${jacoco.master.exec.file}</destFile>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,35 @@
         </pluginManagement>
       </build>
     </profile>
+
+    <profile>
+      <!-- environment-specific profile that should be activated only when running in travis-ci. -->
+      <id>travis-ci</id>
+      <activation>
+        <property>
+          <name>env.TRAVIS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <systemProperties>
+                    <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                    <java.net.preferIPv4Addresses>true</java.net.preferIPv4Addresses>
+                  </systemProperties>
+                </container>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,11 @@
         <version>${version.net.bytebuddy}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.agent</artifactId>
+        <version>${version.jacoco.plugin}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -519,7 +524,6 @@
         <dependency>
           <groupId>org.jacoco</groupId>
           <artifactId>org.jacoco.agent</artifactId>
-          <version>${version.jacoco.plugin}</version>
         </dependency>
       </dependencies>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <version.com.github.nmorel.gwtjackson>0.14.2</version.com.github.nmorel.gwtjackson>
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.io.swagger>1.5.15</version.io.swagger>
-    <version.jacoco.plugin>0.8.2</version.jacoco.plugin>
     <version.net.ltgt.gwt.maven.gwt-maven-plugin>1.0-rc-9</version.net.ltgt.gwt.maven.gwt-maven-plugin>
     <version.org.gwtbootstrap3>0.9.4</version.org.gwtbootstrap3>
     <version.org.jboss.errai>4.3.3.Final</version.org.jboss.errai>
@@ -560,8 +559,7 @@
 
     <profile>
       <!--
-        For automated run, see travis.yml.
-        To report coverage data manually, run "mvn jacoco:merge sonar:sonar" -Preport-code-coverage
+        For running the report manually, please refer to travis.yml.
       -->
       <id>report-code-coverage</id>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
     <version.org.wildfly>14.0.1.Final</version.org.wildfly>
     <version.org.codehaus.cargo.cargo-maven2-plugin>1.6.11</version.org.codehaus.cargo.cargo-maven2-plugin>
 
-    <jacoco.agent.line/>
-    <surefire.argLine>
-      -Dfile.encoding=${project.build.sourceEncoding}
-      ${jacoco.agent.line}
-    </surefire.argLine>
     <!-- gwtmockito uses a different version of mockito than kie-parent, so we need to override the mockito version,
          kie-parent manages version 1.x -->
     <version.org.mockito>2.12.0</version.org.mockito>
@@ -278,11 +273,6 @@
         <artifactId>byte-buddy</artifactId>
         <version>${version.net.bytebuddy}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jacoco</groupId>
-        <artifactId>org.jacoco.agent</artifactId>
-        <version>${version.jacoco.plugin}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -518,13 +508,11 @@
       <properties>
         <jacoco.exec.file>${project.build.directory}/jacoco.exec</jacoco.exec.file>
         <jacoco.agent.line>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${version.jacoco.plugin}/org.jacoco.agent-${version.jacoco.plugin}-runtime.jar=destfile=${jacoco.exec.file},append=true,excludes=*Lexer</jacoco.agent.line>
+        <surefire.argLine>
+          -Dfile.encoding=${project.build.sourceEncoding}
+          ${jacoco.agent.line}
+        </surefire.argLine>
       </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.agent</artifactId>
-        </dependency>
-      </dependencies>
       <build>
         <pluginManagement>
           <plugins>
@@ -538,6 +526,13 @@
                   </properties>
                 </configuration>
               </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.jacoco</groupId>
+                  <artifactId>org.jacoco.agent</artifactId>
+                  <version>${version.jacoco.plugin}</version>
+                </dependency>
+              </dependencies>
             </plugin>
             <plugin>
               <groupId>net.ltgt.gwt.maven</groupId>
@@ -551,6 +546,13 @@
               <configuration>
                 <argLine>${surefire.argLine}</argLine>
               </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.jacoco</groupId>
+                  <artifactId>org.jacoco.agent</artifactId>
+                  <version>${version.jacoco.plugin}</version>
+                </dependency>
+              </dependencies>
             </plugin>
           </plugins>
         </pluginManagement>


### PR DESCRIPTION
- configures JaCoCo code coverage, including integration tests
- uses travis to run tests and upload code quality statistics to sonarcloud.io
- after we give it a try, the JaCoCo configuration will be moved to kie-parent to push it to other projects too