### PR TITLE
PLANNER-1438:  Fix Broken RESTEasy Tests after alignment

### DIFF
--- a/employee-rostering-webapp/pom.xml
+++ b/employee-rostering-webapp/pom.xml
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/employee-rostering-webapp/pom.xml
+++ b/employee-rostering-webapp/pom.xml
@@ -177,6 +177,19 @@
 
   <profiles>
     <profile>
+      <id>productized</id>
+      <activation>
+        <property>
+            <name>productized</name>
+        </property>
+      </activation>
+      <properties>
+        <cargo.maven.skip>true</cargo.maven.skip>
+        <skipITs>true</skipITs>
+      </properties>
+    </profile>
+
+    <profile>
       <id>withGwt</id>
       <activation>
         <property>


### PR DESCRIPTION
@mbiarnes I was able to reproduce the failing tests.  They were due to the exclusion of `jboss-jaxrs-api_2.1_spec`. Removing the exclusion fixes the test. What was the duplication issue with` jboss-jaxrs-api_2.1_spec` (i.e. what dependencies included it)?