### PR TITLE
PLANNER-1442: Add Magic Property that makes MySQL goes faster

### DIFF
--- a/employee-rostering-server/src/main/filtered-resources/META-INF/persistence.xml
+++ b/employee-rostering-server/src/main/filtered-resources/META-INF/persistence.xml
@@ -16,6 +16,8 @@
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
     <properties>
       <property name="hibernate.hbm2ddl.auto" value="${org.optaweb.employeerostering.persistence.hbm2ddl.auto}"/>
+      <!-- Uncomment the property below if you are using MySQL -->
+      <!--<property name="hibernate.id.new_generator_mappings" value="false"/>-->
       <!--<property name="hibernate.show_sql" value="true"/>-->
       <!--<property name="hibernate.format_sql" value="true"/>-->
       <property name="hibernate.dialect" value="${org.optaweb.employeerostering.persistence.dialect}"/>


### PR DESCRIPTION
Reason: MySQL has a poor AUTO id generator, but it used to have a good one, so
setting the magic property to false increases the speed by a factor of at least
3.