### PR TITLE
PLANNER-1587: Move Admin Service and Solver

### DIFF
--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -107,6 +107,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-jackson</artifactId>
+    </dependency>
 
     <!-- Testing dependencies -->
     <dependency>

--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -114,6 +114,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
@@ -16,11 +16,19 @@
 
 package org.optaweb.employeerostering;
 
+import com.fasterxml.jackson.databind.Module;
+import org.optaplanner.persistence.jackson.api.OptaPlannerJacksonModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class OptaWebEmployeeRosteringApplication {
+
+    @Bean
+    public Module OptaplannerModule() {
+        return OptaPlannerJacksonModule.createModule();
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(OptaWebEmployeeRosteringApplication.class, args);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Bean;
 public class OptaWebEmployeeRosteringApplication {
 
     @Bean
-    public Module OptaplannerModule() {
+    public Module getOptaPlannerModule() {
         return OptaPlannerJacksonModule.createModule();
     }
 

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/roster/Pagination.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/roster/Pagination.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.domain.roster;
+
+import static java.lang.Math.max;
+
+public class Pagination {
+
+    private final Integer pageNumber;
+    private final Integer numberOfItemsPerPage;
+
+    /**
+     * @param pageNumber null to retrieve all items
+     * @param numberOfItemsPerPage null to retrieve all items
+     * @return never null
+     */
+    public static Pagination of(final Integer pageNumber,
+                                final Integer numberOfItemsPerPage) {
+        if (pageNumber == null) {
+            if (numberOfItemsPerPage == null) {
+                return new Pagination(0, Integer.MAX_VALUE);
+            } else {
+                throw new IllegalStateException("When pageNumber (" + pageNumber
+                                                        + ") is null, then numberOfItemsPerPage ("
+                                                        + numberOfItemsPerPage + ") must be null too.");
+            }
+        } else if (numberOfItemsPerPage == null) {
+            throw new IllegalStateException("When numberOfItemsPerPage (" + numberOfItemsPerPage
+                                                    + ") is null, then pageNumber (" + pageNumber
+                                                    + ") must be null too.");
+        }
+        return new Pagination(pageNumber, numberOfItemsPerPage);
+    }
+
+    private Pagination(final Integer pageNumber,
+                       final Integer numberOfItemsPerPage) {
+        this.pageNumber = pageNumber;
+        this.numberOfItemsPerPage = numberOfItemsPerPage;
+    }
+
+    public Integer getNumberOfItemsPerPage() {
+        return numberOfItemsPerPage;
+    }
+
+    public Integer getFirstResultIndex() {
+        return pageNumber * numberOfItemsPerPage;
+    }
+
+    public Integer getPageNumber() {
+        return pageNumber;
+    }
+
+    public Pagination nextPage() {
+        return new Pagination(pageNumber + 1, numberOfItemsPerPage);
+    }
+
+    public Pagination previousPage() {
+        return new Pagination(max(0, pageNumber - 1), numberOfItemsPerPage);
+    }
+
+    public Pagination withNumberOfItemsPerPage(final Integer numberOfItemsPerPage) {
+        return new Pagination(pageNumber, numberOfItemsPerPage);
+    }
+
+    public boolean isOnFirstPage() {
+        return pageNumber == 0;
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/roster/PublishResult.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/roster/PublishResult.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.domain.roster;
+
+import java.time.LocalDate;
+
+public class PublishResult {
+
+    private LocalDate publishedFromDate; // Inclusive
+    private LocalDate publishedToDate; // Exclusive
+
+    @SuppressWarnings("unused")
+    public PublishResult() {
+    }
+
+    public PublishResult(LocalDate publishedFromDate, LocalDate publishedToDate) {
+        this.publishedFromDate = publishedFromDate;
+        this.publishedToDate = publishedToDate;
+    }
+
+    public LocalDate getPublishedFromDate() {
+        return publishedFromDate;
+    }
+
+
+    public void setPublishedFromDate(LocalDate publishedFromDate) {
+        this.publishedFromDate = publishedFromDate;
+    }
+
+
+    public LocalDate getPublishedToDate() {
+        return publishedToDate;
+    }
+
+
+    public void setPublishedToDate(LocalDate publishedToDate) {
+        this.publishedToDate = publishedToDate;
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/shift/view/ShiftView.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/shift/view/ShiftView.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaweb.employeerostering.domain.common.AbstractPersistable;
 import org.optaweb.employeerostering.domain.common.DateTimeUtils;
@@ -137,6 +139,7 @@ public class ShiftView extends AbstractPersistable {
         this.spotId = spotId;
     }
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     public LocalDateTime getStartDateTime() {
         return startDateTime;
     }
@@ -145,6 +148,7 @@ public class ShiftView extends AbstractPersistable {
         this.startDateTime = startDateTime;
     }
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     public LocalDateTime getEndDateTime() {
         return endDateTime;
     }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.admin;
+
+import org.springframework.util.Assert;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rest/admin")
+@Validated
+public class AdminController {
+
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+        Assert.notNull(adminService, "adminService must not be null.");
+    }
+
+    @PostMapping("/reset")
+    public void resetApplication() {
+        adminService.resetApplication();
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
@@ -16,6 +16,8 @@
 
 package org.optaweb.employeerostering.service.admin;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,7 +37,8 @@ public class AdminController {
     }
 
     @PostMapping("/reset")
-    public void resetApplication() {
+    public ResponseEntity<Void> resetApplication() {
         adminService.resetApplication();
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.admin;
+
+import org.optaweb.employeerostering.service.employee.EmployeeAvailabilityRepository;
+import org.optaweb.employeerostering.service.employee.EmployeeRepository;
+import org.optaweb.employeerostering.service.roster.RosterGenerator;
+import org.optaweb.employeerostering.service.roster.RosterStateRepository;
+import org.optaweb.employeerostering.service.rotation.ShiftTemplateRepository;
+import org.optaweb.employeerostering.service.shift.ShiftRepository;
+import org.optaweb.employeerostering.service.skill.SkillRepository;
+import org.optaweb.employeerostering.service.spot.SpotRepository;
+import org.optaweb.employeerostering.service.tenant.RosterParametrizationRepository;
+import org.optaweb.employeerostering.service.tenant.TenantRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AdminService {
+
+    private ShiftRepository shiftRepository;
+    private EmployeeAvailabilityRepository employeeAvailabilityRepository;
+    private ShiftTemplateRepository shiftTemplateRepository;
+    private EmployeeRepository employeeRepository;
+    private SpotRepository spotRepository;
+    private SkillRepository skillRepository;
+    private RosterParametrizationRepository rosterParametrizationRepository;
+    private RosterStateRepository rosterStateRepository;
+    private TenantRepository tenantRepository;
+
+    private RosterGenerator rosterGenerator;
+
+    public AdminService(ShiftRepository shiftRepository,
+                        EmployeeAvailabilityRepository employeeAvailabilityRepository,
+                        ShiftTemplateRepository shiftTemplateRepository,
+                        EmployeeRepository employeeRepository, SpotRepository spotRepository,
+                        SkillRepository skillRepository,
+                        RosterParametrizationRepository rosterParametrizationRepository,
+                        RosterStateRepository rosterStateRepository, TenantRepository tenantRepository,
+                        RosterGenerator rosterGenerator) {
+        this.shiftRepository = shiftRepository;
+        this.employeeAvailabilityRepository = employeeAvailabilityRepository;
+        this.shiftTemplateRepository = shiftTemplateRepository;
+        this.employeeRepository = employeeRepository;
+        this.spotRepository = spotRepository;
+        this.skillRepository = skillRepository;
+        this.rosterParametrizationRepository = rosterParametrizationRepository;
+        this.rosterStateRepository = rosterStateRepository;
+        this.tenantRepository = tenantRepository;
+        this.rosterGenerator = rosterGenerator;
+    }
+
+    @Transactional
+    public void resetApplication() {
+        // IMPORTANT: Delete entries that has Many-to-One relations first, otherwise we break referential integrity
+        // TODO: Why aren't Contract entities deleted?
+        deleteAllEntities();
+        rosterGenerator.setUpGeneratedData();
+    }
+
+    @Transactional
+    private void deleteAllEntities() {
+        shiftRepository.deleteAllInBatch();
+        employeeAvailabilityRepository.deleteAllInBatch();
+        shiftTemplateRepository.deleteAllInBatch();
+        employeeRepository.deleteAllInBatch();
+        spotRepository.deleteAllInBatch();
+        skillRepository.deleteAllInBatch();
+        rosterParametrizationRepository.deleteAllInBatch();
+        rosterStateRepository.deleteAllInBatch();
+        tenantRepository.deleteAllInBatch();
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminService.java
@@ -16,6 +16,7 @@
 
 package org.optaweb.employeerostering.service.admin;
 
+import org.optaweb.employeerostering.service.contract.ContractRepository;
 import org.optaweb.employeerostering.service.employee.EmployeeAvailabilityRepository;
 import org.optaweb.employeerostering.service.employee.EmployeeRepository;
 import org.optaweb.employeerostering.service.roster.RosterGenerator;
@@ -36,6 +37,7 @@ public class AdminService {
     private EmployeeAvailabilityRepository employeeAvailabilityRepository;
     private ShiftTemplateRepository shiftTemplateRepository;
     private EmployeeRepository employeeRepository;
+    private ContractRepository contractRepository;
     private SpotRepository spotRepository;
     private SkillRepository skillRepository;
     private RosterParametrizationRepository rosterParametrizationRepository;
@@ -47,15 +49,19 @@ public class AdminService {
     public AdminService(ShiftRepository shiftRepository,
                         EmployeeAvailabilityRepository employeeAvailabilityRepository,
                         ShiftTemplateRepository shiftTemplateRepository,
-                        EmployeeRepository employeeRepository, SpotRepository spotRepository,
+                        EmployeeRepository employeeRepository,
+                        ContractRepository contractRepository,
+                        SpotRepository spotRepository,
                         SkillRepository skillRepository,
                         RosterParametrizationRepository rosterParametrizationRepository,
-                        RosterStateRepository rosterStateRepository, TenantRepository tenantRepository,
+                        RosterStateRepository rosterStateRepository,
+                        TenantRepository tenantRepository,
                         RosterGenerator rosterGenerator) {
         this.shiftRepository = shiftRepository;
         this.employeeAvailabilityRepository = employeeAvailabilityRepository;
         this.shiftTemplateRepository = shiftTemplateRepository;
         this.employeeRepository = employeeRepository;
+        this.contractRepository = contractRepository;
         this.spotRepository = spotRepository;
         this.skillRepository = skillRepository;
         this.rosterParametrizationRepository = rosterParametrizationRepository;
@@ -67,7 +73,6 @@ public class AdminService {
     @Transactional
     public void resetApplication() {
         // IMPORTANT: Delete entries that has Many-to-One relations first, otherwise we break referential integrity
-        // TODO: Why aren't Contract entities deleted?
         deleteAllEntities();
         rosterGenerator.setUpGeneratedData();
     }
@@ -78,6 +83,7 @@ public class AdminService {
         employeeAvailabilityRepository.deleteAllInBatch();
         shiftTemplateRepository.deleteAllInBatch();
         employeeRepository.deleteAllInBatch();
+        contractRepository.deleteAllInBatch();
         spotRepository.deleteAllInBatch();
         skillRepository.deleteAllInBatch();
         rosterParametrizationRepository.deleteAllInBatch();

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminService.java
@@ -77,7 +77,6 @@ public class AdminService {
         rosterGenerator.setUpGeneratedData();
     }
 
-    @Transactional
     private void deleteAllEntities() {
         shiftRepository.deleteAllInBatch();
         employeeAvailabilityRepository.deleteAllInBatch();

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/common/IndictmentUtils.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/common/IndictmentUtils.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.common;
+
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+import org.optaplanner.core.api.score.constraint.Indictment;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+
+import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
+import org.optaweb.employeerostering.domain.roster.Roster;
+import org.optaweb.employeerostering.domain.shift.Shift;
+import org.optaweb.employeerostering.domain.shift.view.ShiftView;
+import org.optaweb.employeerostering.domain.violation.ContractMinutesViolation;
+import org.optaweb.employeerostering.domain.violation.DesiredTimeslotForEmployeeReward;
+import org.optaweb.employeerostering.domain.violation.RequiredSkillViolation;
+import org.optaweb.employeerostering.domain.violation.RotationViolationPenalty;
+import org.optaweb.employeerostering.domain.violation.ShiftEmployeeConflict;
+import org.optaweb.employeerostering.domain.violation.UnassignedShiftPenalty;
+import org.optaweb.employeerostering.domain.violation.UnavailableEmployeeViolation;
+import org.optaweb.employeerostering.domain.violation.UndesiredTimeslotForEmployeePenalty;
+import org.optaweb.employeerostering.service.solver.WannabeSolverManager;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class IndictmentUtils {
+
+    private WannabeSolverManager solverManager;
+
+    private static final String CONSTRAINT_MATCH_PACKAGE = "org.optaweb.employeerostering.service.solver";
+
+    public IndictmentUtils(WannabeSolverManager solverManager) {
+        this.solverManager = solverManager;
+    }
+
+    public Map<Object, Indictment> getIndictmentMapForRoster(Roster roster) {
+        try (ScoreDirector<Roster> scoreDirector = solverManager.getScoreDirector()) {
+            scoreDirector.setWorkingSolution(roster);
+            scoreDirector.calculateScore();
+            return scoreDirector.getIndictmentMap();
+        }
+    }
+
+    public ShiftView getShiftViewWithIndictment(ZoneId zoneId, Shift shift, Indictment indictment) {
+        return new ShiftView(zoneId, shift,
+                             getRequiredSkillViolationList(indictment),
+                             getUnavailableEmployeeViolationList(indictment),
+                             getShiftEmployeeConflictList(indictment),
+                             getDesiredTimeslotForEmployeeRewardList(indictment),
+                             getUndesiredTimeslotForEmployeePenaltyList(indictment),
+                             getRotationViolationPenaltyList(indictment),
+                             getUnassignedShiftPenaltyList(indictment),
+                             getContractMinutesViolationList(indictment),
+                             (indictment != null) ?
+                                     (HardMediumSoftLongScore) indictment.getScore() : HardMediumSoftLongScore.ZERO);
+    }
+
+    public List<RequiredSkillViolation> getRequiredSkillViolationList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("Required skill for a shift"))
+                .map(cm -> new RequiredSkillViolation((Shift) cm.getJustificationList().get(0),
+                                                      (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<UnavailableEmployeeViolation> getUnavailableEmployeeViolationList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("Unavailable time slot for an employee"))
+                .map(cm -> new UnavailableEmployeeViolation((Shift) cm.getJustificationList().get(0),
+                                                            (EmployeeAvailability) cm.getJustificationList().get(1),
+                                                            (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<DesiredTimeslotForEmployeeReward> getDesiredTimeslotForEmployeeRewardList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("Desired time slot for an employee"))
+                .map(cm -> new DesiredTimeslotForEmployeeReward((Shift) cm.getJustificationList().get(0),
+                                                                (EmployeeAvailability) cm.getJustificationList().get(1),
+                                                                (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<UndesiredTimeslotForEmployeePenalty> getUndesiredTimeslotForEmployeePenaltyList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("Undesired time slot for an employee"))
+                .map(cm -> new UndesiredTimeslotForEmployeePenalty((Shift) cm.getJustificationList().get(0),
+                                                                   (EmployeeAvailability) cm.getJustificationList()
+                                                                           .get(1),
+                                                                   (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ShiftEmployeeConflict> getShiftEmployeeConflictList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("At most one shift assignment per day per employee") ||
+                        cm.getConstraintName().equals("No 2 shifts within 10 hours from each other"))
+                .map(cm -> new ShiftEmployeeConflict((Shift) cm.getJustificationList().get(0),
+                                                     (Shift) cm.getJustificationList().get(1),
+                                                     (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<RotationViolationPenalty> getRotationViolationPenaltyList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("Employee is not rotation employee"))
+                .map(cm -> new RotationViolationPenalty((Shift) cm.getJustificationList().get(0),
+                                                        (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<UnassignedShiftPenalty> getUnassignedShiftPenaltyList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        cm.getConstraintName().equals("Assign every shift"))
+                .map(cm -> new UnassignedShiftPenalty((Shift) cm.getJustificationList().get(0),
+                                                      (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ContractMinutesViolation> getContractMinutesViolationList(Indictment indictment) {
+        if (indictment == null) {
+            return Collections.emptyList();
+        }
+        // getJustificationList() was not consistent; sometimes employee was first, other times minutes worked was first
+        return indictment.getConstraintMatchSet().stream()
+                .filter(cm -> cm.getConstraintPackage().equals(CONSTRAINT_MATCH_PACKAGE) &&
+                        (cm.getConstraintName().equals("Daily minutes must not exceed contract maximum") ||
+                                cm.getConstraintName().equals("Weekly minutes must not exceed contract maximum") ||
+                                cm.getConstraintName().equals("Monthly minutes must not exceed contract maximum") ||
+                                cm.getConstraintName().equals("Yearly minutes must not exceed contract maximum")))
+                .map(cm -> new ContractMinutesViolation((Employee) cm.getJustificationList()
+                        .stream()
+                        .filter(o -> o instanceof Employee)
+                        .findFirst().get(), ContractMinutesViolation.Type.getTypeForViolation(cm.getConstraintName()),
+                                                        (Long) cm.getJustificationList()
+                                                                .stream()
+                                                                .filter(o -> o instanceof Long)
+                                                                .findFirst().get(),
+                                                        (HardMediumSoftLongScore) cm.getScore()))
+                .collect(Collectors.toList());
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,7 +70,7 @@ public class ContractController {
         return new ResponseEntity<>(contractService.createContract(tenantId, contractView), HttpStatus.OK);
     }
 
-    @PutMapping("/update")
+    @PostMapping("/update")
     public ResponseEntity<Contract> updateContract(@PathVariable @Min(0) Integer tenantId,
                                                    @RequestBody @Valid ContractView contractView) {
         return new ResponseEntity<>(contractService.updateContract(tenantId, contractView), HttpStatus.OK);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeAvailabilityRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeAvailabilityRepository.java
@@ -16,8 +16,11 @@
 
 package org.optaweb.employeerostering.service.employee;
 
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 
+import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -36,4 +39,14 @@ public interface EmployeeAvailabilityRepository extends JpaRepository<EmployeeAv
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from EmployeeAvailability ea where ea.tenantId = :tenantId")
     void deleteForTenant(Integer tenantId);
+
+    @Query("select distinct ea from EmployeeAvailability ea" +
+            " left join fetch ea.employee e" +
+            " where ea.tenantId = :tenantId" +
+            " and ea.employee IN :employeeSet" +
+            " and ea.endDateTime >= :startDateTime" +
+            " and ea.startDateTime < :endDateTime" +
+            " order by e.name, ea.startDateTime")
+    List<EmployeeAvailability> filterWithEmployee(Integer tenantId, Set<Employee> employeeSet,
+                                                  OffsetDateTime startDateTime, OffsetDateTime endDateTime);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeAvailabilityRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeAvailabilityRepository.java
@@ -16,6 +16,8 @@
 
 package org.optaweb.employeerostering.service.employee;
 
+import java.util.List;
+
 import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -24,6 +26,12 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EmployeeAvailabilityRepository extends JpaRepository<EmployeeAvailability, Long> {
+
+    @Query("select distinct ea from EmployeeAvailability ea" +
+            " left join fetch ea.employee e" +
+            " where ea.tenantId = :tenantId" +
+            " order by e.name, ea.startDateTime")
+    List<EmployeeAvailability> findAllByTenantId(Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from EmployeeAvailability ea where ea.tenantId = :tenantId")

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeController.java
@@ -75,7 +75,7 @@ public class EmployeeController {
         return new ResponseEntity<>(employeeService.createEmployee(tenantId, employeeView), HttpStatus.OK);
     }
 
-    @PutMapping("/update")
+    @PostMapping("/update")
     public ResponseEntity<Employee> updateEmployee(@PathVariable @Min(0) Integer tenantId,
                                                    @RequestBody @Valid EmployeeView employeeView) {
         return new ResponseEntity<>(employeeService.updateEmployee(tenantId, employeeView), HttpStatus.OK);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeRepository.java
@@ -19,6 +19,7 @@ package org.optaweb.employeerostering.service.employee;
 import java.util.List;
 
 import org.optaweb.employeerostering.domain.employee.Employee;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -30,7 +31,7 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     @Query("select e from Employee e " +
             "where e.tenantId = :tenantId " +
             "order by LOWER(e.name)")
-    List<Employee> findAllByTenantId(Integer tenantId);
+    List<Employee> findAllByTenantId(Integer tenantId, Pageable pageable);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Employee e where e.tenantId = :tenantId")

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeService.java
@@ -30,6 +30,7 @@ import org.optaweb.employeerostering.domain.roster.RosterState;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.service.common.AbstractRestService;
 import org.optaweb.employeerostering.service.roster.RosterStateRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,7 +66,7 @@ public class EmployeeService extends AbstractRestService {
 
     @Transactional
     public List<Employee> getEmployeeList(Integer tenantId) {
-        return employeeRepository.findAllByTenantId(tenantId);
+        return employeeRepository.findAllByTenantId(tenantId, PageRequest.of(0, Integer.MAX_VALUE));
     }
 
     @Transactional

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -76,7 +76,7 @@ public class RosterController {
                                                               @RequestParam(name = "p", required = false)
                                                                       Integer pageNumber,
                                                               @RequestParam(name = "n", required = false)
-                                                                          Integer numberOfItemsPerPage,
+                                                                      Integer numberOfItemsPerPage,
                                                               @RequestParam(name = "startDate") String startDateString,
                                                               @RequestParam(name = "endDate") String endDateString) {
         return new ResponseEntity<>(rosterService.getShiftRosterView(tenantId, pageNumber, numberOfItemsPerPage,

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -21,7 +21,9 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.roster.RosterState;
+import org.optaweb.employeerostering.domain.roster.view.AvailabilityRosterView;
 import org.optaweb.employeerostering.domain.roster.view.ShiftRosterView;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.springframework.http.HttpStatus;
@@ -99,7 +101,35 @@ public class RosterController {
     // AvailabilityRosterView
     // ************************************************************************
 
-    // TODO: Add getAvailabilityRosterView() methods once SolverManager and IndictmentUtils are added
+    @GetMapping("/availabilityRosterView/current")
+    public ResponseEntity<AvailabilityRosterView> getCurrentAvailabilityRosterView(
+            @PathVariable @Min(0) Integer tenantId, @RequestParam(name = "p", required = false) Integer pageNumber,
+            @RequestParam(name = "n", required = false) Integer numberOfItemsPerPage) {
+        return new ResponseEntity<>(rosterService.getCurrentAvailabilityRosterView(tenantId, pageNumber,
+                                                                                   numberOfItemsPerPage),
+                                    HttpStatus.OK);
+    }
+
+    @GetMapping("/availabilityRosterView")
+    public ResponseEntity<AvailabilityRosterView> getAvailabilityRosterView(
+            @PathVariable @Min(0) Integer tenantId, @RequestParam(name = "p", required = false) Integer pageNumber,
+            @RequestParam(name = "n", required = false) Integer numberOfItemsPerPage,
+            @RequestParam(name = "startDate") String startDateString,
+            @RequestParam(name = "endDate") String endDateString) {
+        return new ResponseEntity<>(rosterService.getAvailabilityRosterView(tenantId, pageNumber, numberOfItemsPerPage,
+                                                                            startDateString, endDateString),
+                                    HttpStatus.OK);
+    }
+
+    @PostMapping("/availabilityRosterView/for")
+    // TODO naming "for" is too abstract: we might add a sibling rest method that filters on another type than spots too
+    public ResponseEntity<AvailabilityRosterView> getAvailabilityRosterViewFor(
+            @PathVariable @Min(0) Integer tenantId, @RequestParam(name = "startDate") String startDateString,
+            @RequestParam(name = "endDate") String endDateString, @RequestBody @Valid List<Employee> employees) {
+        return new ResponseEntity<>(rosterService.getAvailabilityRosterViewFor(tenantId, startDateString,
+                                                                               endDateString, employees),
+                                    HttpStatus.OK);
+    }
 
     // ************************************************************************
     // Solver methods

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -135,6 +135,16 @@ public class RosterController {
     // Solver methods
     // ************************************************************************
 
+    @PostMapping("/solve")
+    public void solveRoster(@PathVariable @Min(0) Integer tenantId) {
+        rosterService.solveRoster(tenantId);
+    }
+
+    @PostMapping("/terminate")
+    public void terminateRosterEarly(@PathVariable @Min(0) Integer tenantId) {
+        rosterService.terminateRosterEarly(tenantId);
+    }
+
     // ************************************************************************
     // Publishing/Provisioning methods
     // ************************************************************************

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -22,6 +22,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
 import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.roster.PublishResult;
 import org.optaweb.employeerostering.domain.roster.RosterState;
 import org.optaweb.employeerostering.domain.roster.view.AvailabilityRosterView;
 import org.optaweb.employeerostering.domain.roster.view.ShiftRosterView;
@@ -132,7 +133,7 @@ public class RosterController {
     }
 
     // ************************************************************************
-    // Solver methods
+    // Solver
     // ************************************************************************
 
     @PostMapping("/solve")
@@ -146,8 +147,11 @@ public class RosterController {
     }
 
     // ************************************************************************
-    // Publishing/Provisioning methods
+    // Publish
     // ************************************************************************
 
-    // TODO: Implement publishAndProvision()
+    @PostMapping("/publishAndProvision")
+    public ResponseEntity<PublishResult> publishAndProvision(@PathVariable @Min(0) Integer tenantId) {
+        return new ResponseEntity<>(rosterService.publishAndProvision(tenantId), HttpStatus.OK);
+    }
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -16,16 +16,24 @@
 
 package org.optaweb.employeerostering.service.roster;
 
+import java.util.List;
+
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
 import org.optaweb.employeerostering.domain.roster.RosterState;
+import org.optaweb.employeerostering.domain.roster.view.ShiftRosterView;
+import org.optaweb.employeerostering.domain.spot.Spot;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -53,7 +61,39 @@ public class RosterController {
     // ShiftRosterView
     // ************************************************************************
 
-    // TODO: Add getShiftRosterView() methods once SolverManager and IndictmentUtils are added
+    @GetMapping("/shiftRosterView/current")
+    public ResponseEntity<ShiftRosterView> getCurrentShiftRosterView(@PathVariable @Min(0) Integer tenantId,
+                                                                     @RequestParam(name = "p", required = false)
+                                                                             Integer pageNumber,
+                                                                     @RequestParam(name = "n", required = false)
+                                                                             Integer numberOfItemsPerPage) {
+        return new ResponseEntity<>(rosterService.getCurrentShiftRosterView(tenantId, pageNumber,
+                                                                            numberOfItemsPerPage), HttpStatus.OK);
+    }
+
+    @GetMapping("/shiftRosterView")
+    public ResponseEntity<ShiftRosterView> getShiftRosterView(@PathVariable @Min(0) Integer tenantId,
+                                                              @RequestParam(name = "p", required = false)
+                                                                      Integer pageNumber,
+                                                              @RequestParam(name = "n", required = false)
+                                                                          Integer numberOfItemsPerPage,
+                                                              @RequestParam(name = "startDate") String startDateString,
+                                                              @RequestParam(name = "endDate") String endDateString) {
+        return new ResponseEntity<>(rosterService.getShiftRosterView(tenantId, pageNumber, numberOfItemsPerPage,
+                                                                     startDateString, endDateString), HttpStatus.OK);
+    }
+
+    // TODO: find out if there a way to pass lists in GET requests
+    // TODO naming "for" is too abstract: we might add a sibling rest method that filters on another type than spots too
+    @PostMapping("/shiftRosterView/for")
+    public ResponseEntity<ShiftRosterView> getShiftRosterViewFor(@PathVariable @Min(0) Integer tenantId,
+                                                                 @RequestParam(name = "startDate")
+                                                                         String startDateString,
+                                                                 @RequestParam(name = "endDate") String endDateString,
+                                                                 @RequestBody @Valid List<Spot> spots) {
+        return new ResponseEntity<>(rosterService.getShiftRosterViewFor(tenantId, startDateString, endDateString,
+                                                                        spots), HttpStatus.OK);
+    }
 
     // ************************************************************************
     // AvailabilityRosterView

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -61,4 +61,13 @@ public class RosterController {
 
     // TODO: Add getAvailabilityRosterView() methods once SolverManager and IndictmentUtils are added
 
+    // ************************************************************************
+    // Solver methods
+    // ************************************************************************
+
+    // ************************************************************************
+    // Publishing/Provisioning methods
+    // ************************************************************************
+
+    // TODO: Implement publishAndProvision()
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterGenerator.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterGenerator.java
@@ -418,13 +418,6 @@ public class RosterGenerator implements ApplicationRunner {
 
     @Transactional
     public void setUpGeneratedData() {
-        // Check if Tenant entities already exist before generating data
-        List<Tenant> tenantList = entityManager.createQuery("select t from Tenant t").getResultList();
-
-        if (!tenantList.isEmpty()) {
-            return;
-        }
-
         ZoneId zoneId = SystemPropertiesRetriever.determineZoneId();
         SystemPropertiesRetriever.InitialData initialData = SystemPropertiesRetriever.determineInitialData();
 

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -147,14 +147,14 @@ public class RosterService extends AbstractRestService {
 
     @Transactional
     public ShiftRosterView getShiftRosterViewFor(Integer tenantId, String startDateString, String endDateString,
-                                                 List<Spot> spots) {
+                                                 List<Spot> spotList) {
         LocalDate startDate = LocalDate.parse(startDateString);
         LocalDate endDate = LocalDate.parse(endDateString);
-        if (null == spots) {
-            throw new IllegalArgumentException("spots is null!");
+        if (spotList == null) {
+            throw new IllegalArgumentException("The spotList (" + spotList + ") must not be null.");
         }
 
-        return getShiftRosterView(tenantId, startDate, endDate, spots);
+        return getShiftRosterView(tenantId, startDate, endDate, spotList);
     }
 
     private ShiftRosterView getShiftRosterView(Integer tenantId, LocalDate startDate, LocalDate endDate,
@@ -321,7 +321,6 @@ public class RosterService extends AbstractRestService {
                 .map(s -> s.inTimeZone(zoneId))
                 .collect(Collectors.toList());
 
-        // TODO fill in the score too - do we inject a ScoreDirectorFactory?
         Roster roster = new Roster((long) tenantId, tenantId, skillList, spotList, employeeList,
                                    employeeAvailabilityList,
                                    rosterParametrizationRepository

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -324,7 +324,11 @@ public class RosterService extends AbstractRestService {
         // TODO fill in the score too - do we inject a ScoreDirectorFactory?
         Roster roster = new Roster((long) tenantId, tenantId, skillList, spotList, employeeList,
                                    employeeAvailabilityList,
-                                   rosterParametrizationRepository.findByTenantId(tenantId).get(),
+                                   rosterParametrizationRepository
+                                           .findByTenantId(tenantId)
+                                           .orElseThrow(() -> new EntityNotFoundException(
+                                                   "No RosterParametrization entity found with tenantId(" + tenantId +
+                                                           ").")),
                                    getRosterState(tenantId), shiftList);
         ScoreDirector<Roster> scoreDirector = solverManager.getScoreDirector();
         scoreDirector.setWorkingSolution(roster);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -149,7 +149,8 @@ public class RosterService extends AbstractRestService {
                                                List<Spot> spotList) {
         ShiftRosterView shiftRosterView = new ShiftRosterView(tenantId, startDate, endDate);
         shiftRosterView.setSpotList(spotList);
-        List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId);
+        List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId, PageRequest.of(0,
+                                                                                                    Integer.MAX_VALUE));
         shiftRosterView.setEmployeeList(employeeList);
 
         Set<Spot> spotSet = new HashSet<>(spotList);
@@ -196,7 +197,8 @@ public class RosterService extends AbstractRestService {
         ZoneId zoneId = getRosterState(tenantId).getTimeZone();
         List<Skill> skillList = skillRepository.findAllByTenantId(tenantId);
         List<Spot> spotList = spotRepository.findAllByTenantId(tenantId, PageRequest.of(0, Integer.MAX_VALUE));
-        List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId);
+        List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId, PageRequest.of(0,
+                                                                                                    Integer.MAX_VALUE));
         List<EmployeeAvailability> employeeAvailabilityList = employeeAvailabilityRepository.findAllByTenantId(tenantId)
                 .stream()
                 .map(ea -> ea.inTimeZone(zoneId))
@@ -216,7 +218,8 @@ public class RosterService extends AbstractRestService {
     public void updateShiftsOfRoster(Roster newRoster) {
         Integer tenantId = newRoster.getTenantId();
         // TODO HACK avoids optimistic locking exception while solve(), but it circumvents optimistic locking completely
-        Map<Long, Employee> employeeIdMap = employeeRepository.findAllByTenantId(tenantId)
+        Map<Long, Employee> employeeIdMap = employeeRepository.findAllByTenantId(tenantId,
+                                                                                 PageRequest.of(0, Integer.MAX_VALUE))
                 .stream()
                 .collect(Collectors.toMap(Employee::getId, Function.identity()));
 

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -93,7 +93,7 @@ public class RosterService extends AbstractRestService {
     // TODO: Add getAvailabilityRosterView() methods once SolverManager and IndictmentUtils are added
 
     // ************************************************************************
-    // Other
+    // Roster
     // ************************************************************************
 
     @Transactional
@@ -138,4 +138,14 @@ public class RosterService extends AbstractRestService {
                     null : employeeIdMap.get(shift.getEmployee().getId()));
         }
     }
+
+    // ************************************************************************
+    // Solver methods
+    // ************************************************************************
+
+    // ************************************************************************
+    // Publishing/Provisioning methods
+    // ************************************************************************
+
+    // TODO: Implement PublishAndProvision()
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -38,6 +38,7 @@ import org.optaweb.employeerostering.service.shift.ShiftRepository;
 import org.optaweb.employeerostering.service.skill.SkillRepository;
 import org.optaweb.employeerostering.service.spot.SpotRepository;
 import org.optaweb.employeerostering.service.tenant.RosterParametrizationRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -100,7 +101,7 @@ public class RosterService extends AbstractRestService {
     public Roster buildRoster(Integer tenantId) {
         ZoneId zoneId = getRosterState(tenantId).getTimeZone();
         List<Skill> skillList = skillRepository.findAllByTenantId(tenantId);
-        List<Spot> spotList = spotRepository.findAllByTenantId(tenantId);
+        List<Spot> spotList = spotRepository.findAllByTenantId(tenantId, PageRequest.of(0, Integer.MAX_VALUE));
         List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId);
         List<EmployeeAvailability> employeeAvailabilityList = employeeAvailabilityRepository.findAllByTenantId(tenantId)
                 .stream()

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -16,10 +16,27 @@
 
 package org.optaweb.employeerostering.service.roster;
 
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import javax.persistence.EntityNotFoundException;
 
+import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
+import org.optaweb.employeerostering.domain.roster.Roster;
 import org.optaweb.employeerostering.domain.roster.RosterState;
+import org.optaweb.employeerostering.domain.skill.Skill;
+import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.service.common.AbstractRestService;
+import org.optaweb.employeerostering.service.employee.EmployeeAvailabilityRepository;
+import org.optaweb.employeerostering.service.employee.EmployeeRepository;
+import org.optaweb.employeerostering.service.skill.SkillRepository;
+import org.optaweb.employeerostering.service.spot.SpotRepository;
+import org.optaweb.employeerostering.service.tenant.RosterParametrizationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,9 +44,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class RosterService extends AbstractRestService {
 
     private final RosterStateRepository rosterStateRepository;
+    private final SkillRepository skillRepository;
+    private final SpotRepository spotRepository;
+    private final EmployeeRepository employeeRepository;
+    private final EmployeeAvailabilityRepository employeeAvailabilityRepository;
+    private final RosterParametrizationRepository rosterParametrizationRepository;
 
-    public RosterService(RosterStateRepository rosterStateRepository) {
+    public RosterService(RosterStateRepository rosterStateRepository, SkillRepository skillRepository,
+                         SpotRepository spotRepository, EmployeeRepository employeeRepository,
+                         EmployeeAvailabilityRepository employeeAvailabilityRepository,
+                         RosterParametrizationRepository rosterParametrizationRepository) {
         this.rosterStateRepository = rosterStateRepository;
+        this.skillRepository = skillRepository;
+        this.spotRepository = spotRepository;
+        this.employeeRepository = employeeRepository;
+        this.employeeAvailabilityRepository = employeeAvailabilityRepository;
+        this.rosterParametrizationRepository = rosterParametrizationRepository;
     }
 
     // ************************************************************************
@@ -58,4 +88,64 @@ public class RosterService extends AbstractRestService {
 
     // TODO: Add getAvailabilityRosterView() methods once SolverManager and IndictmentUtils are added
 
+    // ************************************************************************
+    // Other
+    // ************************************************************************
+
+    @Transactional
+    public Roster buildRoster(Integer tenantId) {
+        ZoneId zoneId = getRosterState(tenantId).getTimeZone();
+        List<Skill> skillList = skillRepository.findAllByTenantId(tenantId);
+        List<Spot> spotList = spotRepository.findAllByTenantId(tenantId);
+        List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId);
+        List<EmployeeAvailability> employeeAvailabilityList = employeeAvailabilityRepository
+                .findAllByTenantId(tenantId)
+                .stream()
+                .map(ea -> ea.inTimeZone(zoneId))
+                .collect(Collectors.toList());
+
+        // TODO: Fetch ShiftList once Shift CRUD methods are implemented
+        /*
+        List<Shift> shiftList = entityManager.createNamedQuery("Shift.findAll", Shift.class)
+                .setParameter("tenantId", tenantId)
+                .getResultList()
+                .stream()
+                .map(s -> s.inTimeZone(zoneId))
+                .collect(Collectors.toList());
+        */
+
+        // TODO fill in the score too - do we inject a ScoreDirectorFactory?
+        // TODO: Put ShiftList in Roster once it's fetched above
+        return new Roster((long) tenantId, tenantId, skillList, spotList, employeeList, employeeAvailabilityList,
+                          rosterParametrizationRepository.findByTenantId(tenantId).get(), getRosterState(tenantId),
+                          Collections.emptyList());
+    }
+
+    @Transactional
+    public void updateShiftsOfRoster(Roster newRoster) {
+        Integer tenantId = newRoster.getTenantId();
+        // TODO HACK avoids optimistic locking exception while solve(), but it circumvents optimistic locking completely
+        Map<Long, Employee> employeeIdMap = employeeRepository.findAllByTenantId(tenantId)
+                .stream()
+                .collect(Collectors.toMap(Employee::getId, Function.identity()));
+
+        // TODO: Fetch ShiftMap once Shift CRUD methods are implemented
+        /*
+        Map<Long, Shift> shiftIdMap = entityManager.createNamedQuery("Shift.findAll", Shift.class)
+                .setParameter("tenantId", tenantId)
+                .getResultList().stream().collect(Collectors.toMap(Shift::getId, Function.identity()));
+         */
+
+        // TODO: Update ShiftList once ShiftMap is created above
+        /*
+        for (Shift shift : newRoster.getShiftList()) {
+            Shift attachedShift = shiftIdMap.get(shift.getId());
+            if (attachedShift == null) {
+                continue;
+            }
+            attachedShift.setEmployee((shift.getEmployee() == null)
+                                              ? null : employeeIdMap.get(shift.getEmployee().getId()));
+        }
+         */
+    }
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -17,7 +17,6 @@
 package org.optaweb.employeerostering.service.roster;
 
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -29,11 +28,13 @@ import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
 import org.optaweb.employeerostering.domain.roster.Roster;
 import org.optaweb.employeerostering.domain.roster.RosterState;
+import org.optaweb.employeerostering.domain.shift.Shift;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.service.common.AbstractRestService;
 import org.optaweb.employeerostering.service.employee.EmployeeAvailabilityRepository;
 import org.optaweb.employeerostering.service.employee.EmployeeRepository;
+import org.optaweb.employeerostering.service.shift.ShiftRepository;
 import org.optaweb.employeerostering.service.skill.SkillRepository;
 import org.optaweb.employeerostering.service.spot.SpotRepository;
 import org.optaweb.employeerostering.service.tenant.RosterParametrizationRepository;
@@ -48,17 +49,20 @@ public class RosterService extends AbstractRestService {
     private final SpotRepository spotRepository;
     private final EmployeeRepository employeeRepository;
     private final EmployeeAvailabilityRepository employeeAvailabilityRepository;
+    private final ShiftRepository shiftRepository;
     private final RosterParametrizationRepository rosterParametrizationRepository;
 
     public RosterService(RosterStateRepository rosterStateRepository, SkillRepository skillRepository,
                          SpotRepository spotRepository, EmployeeRepository employeeRepository,
                          EmployeeAvailabilityRepository employeeAvailabilityRepository,
+                         ShiftRepository shiftRepository,
                          RosterParametrizationRepository rosterParametrizationRepository) {
         this.rosterStateRepository = rosterStateRepository;
         this.skillRepository = skillRepository;
         this.spotRepository = spotRepository;
         this.employeeRepository = employeeRepository;
         this.employeeAvailabilityRepository = employeeAvailabilityRepository;
+        this.shiftRepository = shiftRepository;
         this.rosterParametrizationRepository = rosterParametrizationRepository;
     }
 
@@ -98,27 +102,19 @@ public class RosterService extends AbstractRestService {
         List<Skill> skillList = skillRepository.findAllByTenantId(tenantId);
         List<Spot> spotList = spotRepository.findAllByTenantId(tenantId);
         List<Employee> employeeList = employeeRepository.findAllByTenantId(tenantId);
-        List<EmployeeAvailability> employeeAvailabilityList = employeeAvailabilityRepository
-                .findAllByTenantId(tenantId)
+        List<EmployeeAvailability> employeeAvailabilityList = employeeAvailabilityRepository.findAllByTenantId(tenantId)
                 .stream()
                 .map(ea -> ea.inTimeZone(zoneId))
                 .collect(Collectors.toList());
-
-        // TODO: Fetch ShiftList once Shift CRUD methods are implemented
-        /*
-        List<Shift> shiftList = entityManager.createNamedQuery("Shift.findAll", Shift.class)
-                .setParameter("tenantId", tenantId)
-                .getResultList()
+        List<Shift> shiftList = shiftRepository.findAllByTenantId(tenantId)
                 .stream()
                 .map(s -> s.inTimeZone(zoneId))
                 .collect(Collectors.toList());
-        */
 
         // TODO fill in the score too - do we inject a ScoreDirectorFactory?
-        // TODO: Put ShiftList in Roster once it's fetched above
         return new Roster((long) tenantId, tenantId, skillList, spotList, employeeList, employeeAvailabilityList,
-                          rosterParametrizationRepository.findByTenantId(tenantId).get(), getRosterState(tenantId),
-                          Collections.emptyList());
+                rosterParametrizationRepository.findByTenantId(tenantId).get(), getRosterState(tenantId),
+                shiftList);
     }
 
     @Transactional
@@ -129,23 +125,17 @@ public class RosterService extends AbstractRestService {
                 .stream()
                 .collect(Collectors.toMap(Employee::getId, Function.identity()));
 
-        // TODO: Fetch ShiftMap once Shift CRUD methods are implemented
-        /*
-        Map<Long, Shift> shiftIdMap = entityManager.createNamedQuery("Shift.findAll", Shift.class)
-                .setParameter("tenantId", tenantId)
-                .getResultList().stream().collect(Collectors.toMap(Shift::getId, Function.identity()));
-         */
+        Map<Long, Shift> shiftIdMap = shiftRepository.findAllByTenantId(tenantId)
+                .stream()
+                .collect(Collectors.toMap(Shift::getId, Function.identity()));
 
-        // TODO: Update ShiftList once ShiftMap is created above
-        /*
         for (Shift shift : newRoster.getShiftList()) {
             Shift attachedShift = shiftIdMap.get(shift.getId());
             if (attachedShift == null) {
                 continue;
             }
-            attachedShift.setEmployee((shift.getEmployee() == null)
-                                              ? null : employeeIdMap.get(shift.getEmployee().getId()));
+            attachedShift.setEmployee((shift.getEmployee() == null) ?
+                    null : employeeIdMap.get(shift.getEmployee().getId()));
         }
-         */
     }
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -346,6 +346,14 @@ public class RosterService extends AbstractRestService {
     // Solver methods
     // ************************************************************************
 
+    public void solveRoster(Integer tenantId) {
+        solverManager.solve(tenantId);
+    }
+
+    public void terminateRosterEarly(Integer tenantId) {
+        solverManager.terminate(tenantId);
+    }
+
     // ************************************************************************
     // Publishing/Provisioning methods
     // ************************************************************************

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterService.java
@@ -134,7 +134,6 @@ public class RosterService extends AbstractRestService {
                                   Pagination.of(pageNumber, numberOfItemsPerPage));
     }
 
-    @Transactional
     private ShiftRosterView getShiftRosterView(final Integer tenantId,
                                                final LocalDate startDate,
                                                final LocalDate endDate,
@@ -158,7 +157,6 @@ public class RosterService extends AbstractRestService {
         return getShiftRosterView(tenantId, startDate, endDate, spots);
     }
 
-    @Transactional
     private ShiftRosterView getShiftRosterView(Integer tenantId, LocalDate startDate, LocalDate endDate,
                                                List<Spot> spotList) {
         ShiftRosterView shiftRosterView = new ShiftRosterView(tenantId, startDate, endDate);
@@ -234,7 +232,6 @@ public class RosterService extends AbstractRestService {
         return getAvailabilityRosterView(tenantId, startDate, endDate, employeeList);
     }
 
-    @Transactional
     private AvailabilityRosterView getAvailabilityRosterView(final Integer tenantId,
                                                              final LocalDate startDate,
                                                              final LocalDate endDate,
@@ -246,7 +243,6 @@ public class RosterService extends AbstractRestService {
         return getAvailabilityRosterView(tenantId, startDate, endDate, employeeList);
     }
 
-    @Transactional
     private AvailabilityRosterView getAvailabilityRosterView(Integer tenantId,
                                                              LocalDate startDate,
                                                              LocalDate endDate,

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftController.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.shift;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+
+import org.optaweb.employeerostering.domain.shift.view.ShiftView;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/rest/tenant/{tenantId}/shift")
+@Validated
+public class ShiftController {
+
+    private final ShiftService shiftService;
+
+    public ShiftController(ShiftService shiftService) {
+        this.shiftService = shiftService;
+        Assert.notNull(shiftService, "shiftService must not be null.");
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<ShiftView>> getShiftList(@PathVariable @Min(0) Integer tenantId) {
+        return new ResponseEntity<>(shiftService.getShiftList(tenantId), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ShiftView> getShift(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
+        return new ResponseEntity<>(shiftService.getShift(tenantId, id), HttpStatus.OK);
+    }
+
+    /**
+     * @param id never null
+     * @return return true if the shift was removed, false otherwise
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Boolean> deleteShift(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
+        return new ResponseEntity<>(shiftService.deleteShift(tenantId, id), HttpStatus.OK);
+    }
+
+    /**
+     * @param shiftView never null
+     * @return never null, the id
+     */
+    @PostMapping("/add")
+    public ResponseEntity<ShiftView> createShift(@PathVariable @Min(0) Integer tenantId,
+                                                 @RequestBody @Valid ShiftView shiftView) {
+        return new ResponseEntity<>(shiftService.createShift(tenantId, shiftView), HttpStatus.OK);
+    }
+
+    /**
+     * @param shiftView never null
+     */
+    @PutMapping("/update")
+    public ResponseEntity<ShiftView> updateShift(@PathVariable @Min(0) Integer tenantId,
+                                                 @RequestBody @Valid ShiftView shiftView) {
+        return new ResponseEntity<>(shiftService.updateShift(tenantId, shiftView), HttpStatus.OK);
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
@@ -16,9 +16,12 @@
 
 package org.optaweb.employeerostering.service.shift;
 
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 
 import org.optaweb.employeerostering.domain.shift.Shift;
+import org.optaweb.employeerostering.domain.spot.Spot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -39,4 +42,16 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
     @Query("delete from Shift s" +
             " where s.tenantId = :tenantId")
     void deleteForTenant(Integer tenantId);
+
+    @Query("select distinct sa from Shift sa" +
+            " left join fetch sa.spot s" +
+            " left join fetch sa.rotationEmployee re" +
+            " left join fetch sa.employee e" +
+            " where sa.tenantId = :tenantId" +
+            " and sa.spot IN :spotSet" +
+            " and sa.endDateTime >= :startDateTime" +
+            " and sa.startDateTime < :endDateTime" +
+            " order by sa.startDateTime, s.name, e.name")
+    List<Shift> filterWithSpots(Integer tenantId, Set<Spot> spotSet, OffsetDateTime startDateTime,
+                                OffsetDateTime endDateTime);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
@@ -20,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
 
+import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.shift.Shift;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -54,4 +55,16 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             " order by sa.startDateTime, s.name, e.name")
     List<Shift> filterWithSpots(Integer tenantId, Set<Spot> spotSet, OffsetDateTime startDateTime,
                                 OffsetDateTime endDateTime);
+
+    @Query("select distinct sa from Shift sa" +
+            " left join fetch sa.spot s" +
+            " left join fetch sa.rotationEmployee re" +
+            " left join fetch sa.employee e" +
+            " where sa.tenantId = :tenantId" +
+            " and sa.employee IN :employeeSet" +
+            " and sa.endDateTime >= :startDateTime" +
+            " and sa.startDateTime < :endDateTime" +
+            " order by sa.startDateTime, s.name, e.name")
+    List<Shift> filterWithEmployees(Integer tenantId, Set<Employee> employeeSet, OffsetDateTime startDateTime,
+                                    OffsetDateTime endDateTime);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.shift;
+
+import java.util.List;
+
+import org.optaweb.employeerostering.domain.shift.Shift;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ShiftRepository extends JpaRepository<Shift, Long> {
+
+    @Query("select distinct sa from Shift sa" +
+            " left join fetch sa.spot s" +
+            " left join fetch sa.rotationEmployee re" +
+            " left join fetch sa.employee e" +
+            " where sa.tenantId = :tenantId" +
+            " order by sa.startDateTime, s.name, e.name")
+    List<Shift> findAllByTenantId(Integer tenantId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from Shift s" +
+            " where s.tenantId = :tenantId")
+    void deleteForTenant(Integer tenantId);
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,7 +68,7 @@ public class SkillController {
         return new ResponseEntity<>(skillService.createSkill(tenantId, skillView), HttpStatus.OK);
     }
 
-    @PutMapping("/update")
+    @PostMapping("/update")
     public ResponseEntity<Skill> updateSkill(@PathVariable @Min(0) Integer tenantId,
                                              @RequestBody @Valid SkillView skillView) {
         return new ResponseEntity<>(skillService.updateSkill(tenantId, skillView), HttpStatus.OK);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/SolverStatus.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/SolverStatus.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.solver;
+
+public enum SolverStatus {
+    SCHEDULED,
+    SOLVING,
+    TERMINATED
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/WannabeSolverManager.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/WannabeSolverManager.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.service.solver;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.score.director.ScoreDirectorFactory;
+import org.optaweb.employeerostering.domain.roster.Roster;
+import org.optaweb.employeerostering.service.roster.RosterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.ApplicationScope;
+
+// TODO Replace by real SolverManager once it exists in optaplanner-core
+@ApplicationScope
+@Component
+public class WannabeSolverManager implements ApplicationRunner {
+
+    public static final String SOLVER_CONFIG = "org/optaweb/employeerostering/service/solver/" +
+            "employeeRosteringSolverConfig.xml";
+
+    protected final transient Logger logger = LoggerFactory.getLogger(getClass());
+
+    private SolverFactory<Roster> solverFactory;
+    private ScoreDirectorFactory<Roster> scoreDirectorFactory;
+
+    // TODO Needs to default to size Math.max(1, Runtime.getRuntime().availableProcessors() - 2);
+    private ThreadPoolTaskExecutor taskExecutor;
+
+    private RosterService rosterService;
+
+    private ConcurrentMap<Integer, SolverStatus> tenantIdToSolverStateMap = new ConcurrentHashMap<>();
+    private ConcurrentMap<Integer, Solver<Roster>> tenantIdToSolverMap = new ConcurrentHashMap<>();
+
+    public WannabeSolverManager(ThreadPoolTaskExecutor taskExecutor, RosterService rosterService) {
+        this.taskExecutor = taskExecutor;
+        this.rosterService = rosterService;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        setUpSolverFactory();
+    }
+
+    public void setUpSolverFactory() {
+        solverFactory = SolverFactory.createFromXmlResource(SOLVER_CONFIG);
+        scoreDirectorFactory = solverFactory.buildSolver().getScoreDirectorFactory();
+    }
+
+    public void terminate(Integer tenantId) {
+        Solver<Roster> solver = tenantIdToSolverMap.get(tenantId);
+
+        if (null != solver) {
+            solver.terminateEarly();
+        } else {
+            throw new IllegalStateException("The roster with tenantId (" + tenantId
+                                                    + ") is not being solved currently.");
+        }
+    }
+
+    public void solve(Integer tenantId) {
+        logger.info("Scheduling solver for tenantId ({})...", tenantId);
+        // No 2 solve() calls of the same dataset in parallel
+        tenantIdToSolverStateMap.compute(tenantId, (k, solverStatus) -> {
+            if (solverStatus != null && solverStatus != SolverStatus.TERMINATED) {
+                throw new IllegalStateException("The roster with tenantId (" + tenantId + ") is already solving " +
+                                                        "with solverStatus (" + solverStatus + ").");
+            }
+            return SolverStatus.SCHEDULED;
+        });
+        taskExecutor.execute(() -> {
+            try {
+                Solver<Roster> solver = solverFactory.buildSolver();
+                tenantIdToSolverMap.put(tenantId, solver);
+                solver.addEventListener(event -> {
+                    if (event.isEveryProblemFactChangeProcessed()) {
+                        logger.info("  New best solution found for tenantId ({}).", tenantId);
+                        Roster newBestRoster = event.getNewBestSolution();
+                        // TODO if this throws an OptimisticLockingException, does it kill the solver?
+                        rosterService.updateShiftsOfRoster(newBestRoster);
+                    }
+                });
+                Roster roster = rosterService.buildRoster(tenantId);
+                try {
+                    tenantIdToSolverStateMap.put(tenantId, SolverStatus.SOLVING);
+                    // TODO No need to store the returned roster because the SolverEventListener already does it?
+                    solver.solve(roster);
+                } finally {
+                    tenantIdToSolverMap.remove(tenantId);
+                    tenantIdToSolverStateMap.put(tenantId, SolverStatus.TERMINATED);
+                }
+            } catch (Throwable e) {
+                // TODO handle errors through Thread'sExceptionHandler
+                logger.error("Error solving for tenantId (" + tenantId + ").", e);
+            }
+        });
+    }
+
+    public Roster getRoster(final Integer tenantId) {
+        Solver<Roster> solver = tenantIdToSolverMap.get(tenantId);
+        return solver == null ? null : solver.getBestSolution();
+    }
+
+    public ScoreDirector<Roster> getScoreDirector() {
+        return scoreDirectorFactory.buildScoreDirector();
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/WannabeSolverManager.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/WannabeSolverManager.java
@@ -65,7 +65,7 @@ public class WannabeSolverManager implements ApplicationRunner {
     }
 
     public void setUpSolverFactory() {
-        solverFactory = SolverFactory.createFromXmlResource(SOLVER_CONFIG);
+        solverFactory = SolverFactory.createFromXmlResource(SOLVER_CONFIG, WannabeSolverManager.class.getClassLoader());
         scoreDirectorFactory = solverFactory.buildSolver().getScoreDirectorFactory();
     }
 
@@ -102,7 +102,7 @@ public class WannabeSolverManager implements ApplicationRunner {
                         rosterService.updateShiftsOfRoster(newBestRoster);
                     }
                 });
-                Roster roster = rosterService.buildRoster(tenantId);
+                Roster roster = rosterService.buildRoster(tenantId); // TODO rename to rosterService.loadRoster
                 try {
                     tenantIdToSolverStateMap.put(tenantId, SolverStatus.SOLVING);
                     // TODO No need to store the returned roster because the SolverEventListener already does it?

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,7 +68,7 @@ public class SpotController {
         return new ResponseEntity<>(spotService.createSpot(tenantId, spotView), HttpStatus.OK);
     }
 
-    @PutMapping("/update")
+    @PostMapping("/update")
     public ResponseEntity<Spot> updateSpot(@PathVariable @Min(0) Integer tenantId,
                                            @RequestBody @Valid SpotView spotView) {
         return new ResponseEntity<>(spotService.updateSpot(tenantId, spotView), HttpStatus.OK);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotRepository.java
@@ -19,6 +19,7 @@ package org.optaweb.employeerostering.service.spot;
 import java.util.List;
 
 import org.optaweb.employeerostering.domain.spot.Spot;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -30,7 +31,7 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
     @Query("select s from Spot s " +
             "where s.tenantId = :tenantId " +
             "order by LOWER(s.name)")
-    List<Spot> findAllByTenantId(Integer tenantId);
+    List<Spot> findAllByTenantId(Integer tenantId, Pageable pageable);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Spot s where s.tenantId = :tenantId")

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotService.java
@@ -24,6 +24,7 @@ import javax.persistence.EntityNotFoundException;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.domain.spot.view.SpotView;
 import org.optaweb.employeerostering.service.common.AbstractRestService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,7 +47,7 @@ public class SpotService extends AbstractRestService {
 
     @Transactional
     public List<Spot> getSpotList(Integer tenantId) {
-        return spotRepository.findAllByTenantId(tenantId);
+        return spotRepository.findAllByTenantId(tenantId, PageRequest.of(0, Integer.MAX_VALUE));
     }
 
     @Transactional

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/TenantService.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/TenantService.java
@@ -32,6 +32,7 @@ import org.optaweb.employeerostering.service.employee.EmployeeAvailabilityReposi
 import org.optaweb.employeerostering.service.employee.EmployeeRepository;
 import org.optaweb.employeerostering.service.roster.RosterStateRepository;
 import org.optaweb.employeerostering.service.rotation.ShiftTemplateRepository;
+import org.optaweb.employeerostering.service.shift.ShiftRepository;
 import org.optaweb.employeerostering.service.skill.SkillRepository;
 import org.optaweb.employeerostering.service.spot.SpotRepository;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,8 @@ public class TenantService extends AbstractRestService {
 
     private final RosterStateRepository rosterStateRepository;
 
+    private final ShiftRepository shiftRepository;
+
     private final EmployeeAvailabilityRepository employeeAvailabilityRepository;
 
     private final ShiftTemplateRepository shiftTemplateRepository;
@@ -59,6 +62,7 @@ public class TenantService extends AbstractRestService {
     public TenantService(TenantRepository tenantRepository,
                          RosterParametrizationRepository rosterParametrizationRepository,
                          RosterStateRepository rosterStateRepository,
+                         ShiftRepository shiftRepository,
                          EmployeeAvailabilityRepository employeeAvailabilityRepository,
                          ShiftTemplateRepository shiftTemplateRepository,
                          EmployeeRepository employeeRepository,
@@ -67,6 +71,7 @@ public class TenantService extends AbstractRestService {
         this.tenantRepository = tenantRepository;
         this.rosterParametrizationRepository = rosterParametrizationRepository;
         this.rosterStateRepository = rosterStateRepository;
+        this.shiftRepository = shiftRepository;
         this.employeeAvailabilityRepository = employeeAvailabilityRepository;
         this.shiftTemplateRepository = shiftTemplateRepository;
         this.employeeRepository = employeeRepository;
@@ -126,7 +131,7 @@ public class TenantService extends AbstractRestService {
         // Employee, Spot, Skill,
         // RosterParametrization, RosterState
 
-        // TODO: Execute Shift.deleteForTenant once Shift CRUD is implemented
+        shiftRepository.deleteForTenant(id);
         employeeAvailabilityRepository.deleteForTenant(id);
         shiftTemplateRepository.deleteForTenant(id);
         employeeRepository.deleteForTenant(id);

--- a/employee-rostering-backend/src/main/resources/application.properties
+++ b/employee-rostering-backend/src/main/resources/application.properties
@@ -1,2 +1,8 @@
-# Enabling H2 Console
+# Enable H2 Console
 spring.h2.console.enabled=true
+
+# Set logging levels
+logging.level.root=WARN
+logging.level.org.springframework=WARN
+logging.level.org.drools=INFO
+logging.level.org.optaplanner.core=INFO

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/admin/AdminRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/admin/AdminRestControllerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.admin;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class AdminRestControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private final String adminPathURI = "http://localhost:8080/rest/admin/";
+
+    private ResponseEntity<Void> resetApplication() {
+        return restTemplate.postForEntity(adminPathURI + "reset", null, Void.class);
+    }
+
+    @Test
+    public void resetApplicationTest() {
+        ResponseEntity<Void> resetResponse = resetApplication();
+        assertThat(resetResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractRestControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,9 +63,8 @@ public class ContractRestControllerTest extends AbstractEntityRequireTenantRestS
         return restTemplate.postForEntity(contractPathURI + "add", contractView, Contract.class, tenantId);
     }
 
-    private ResponseEntity<Contract> updateContract(Integer tenantId, HttpEntity<ContractView> request) {
-        return restTemplate.exchange(contractPathURI + "update", HttpMethod.PUT, request, Contract.class,
-                tenantId);
+    private ResponseEntity<Contract> updateContract(Integer tenantId, ContractView contractView) {
+        return restTemplate.postForEntity(contractPathURI + "update", contractView, Contract.class, tenantId);
     }
 
     @Before
@@ -98,8 +96,7 @@ public class ContractRestControllerTest extends AbstractEntityRequireTenantRestS
         ContractView updatedContractView = new ContractView(TENANT_ID, "updatedContract", maximumMinutesPerDay,
                 maximumMinutesPerWeek, maximumMinutesPerMonth, maximumMinutesPerYear);
         updatedContractView.setId(postResponse.getBody().getId());
-        HttpEntity<ContractView> request = new HttpEntity<>(updatedContractView);
-        ResponseEntity<Contract> putResponse = updateContract(TENANT_ID, request);
+        ResponseEntity<Contract> putResponse = updateContract(TENANT_ID, updatedContractView);
         assertThat(putResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         response = getContract(TENANT_ID, putResponse.getBody().getId());

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractServiceTest.java
@@ -216,7 +216,7 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
         String body = (new ObjectMapper()).writeValueAsString(updatedContractView);
 
         mvc.perform(MockMvcRequestBuilders
-                .put("/rest/tenant/{tenantId}/contract/update", TENANT_ID)
+                .post("/rest/tenant/{tenantId}/contract/update", TENANT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body)
                 .accept(MediaType.APPLICATION_JSON))
@@ -240,7 +240,7 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/contract/update", 0)
+                        .post("/rest/tenant/{tenantId}/contract/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: " +
@@ -256,7 +256,7 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/contract/update", TENANT_ID)
+                        .post("/rest/tenant/{tenantId}/contract/update", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
@@ -274,7 +274,7 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/contract/update", 0)
+                        .post("/rest/tenant/{tenantId}/contract/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalState" +

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeRestControllerTest.java
@@ -75,8 +75,8 @@ public class EmployeeRestControllerTest extends AbstractEntityRequireTenantRestS
         return restTemplate.postForEntity(employeePathURI + "add", employee, Employee.class, tenantId);
     }
 
-    private ResponseEntity<Employee> updateEmployee(Integer tenantId, HttpEntity<Employee> request) {
-        return restTemplate.exchange(employeePathURI + "update", HttpMethod.PUT, request, Employee.class, tenantId);
+    private ResponseEntity<Employee> updateEmployee(Integer tenantId, Employee employee) {
+        return restTemplate.postForEntity(employeePathURI + "update", employee, Employee.class, tenantId);
     }
 
     private ResponseEntity<Skill> addSkill(Integer tenantId, Skill skill) {
@@ -147,8 +147,7 @@ public class EmployeeRestControllerTest extends AbstractEntityRequireTenantRestS
 
         Employee updatedEmployee = new Employee(TENANT_ID, "updatedEmployee", contractA, testSkillSet);
         updatedEmployee.setId(postResponse.getBody().getId());
-        HttpEntity<Employee> request = new HttpEntity<>(updatedEmployee);
-        ResponseEntity<Employee> putResponse = updateEmployee(TENANT_ID, request);
+        ResponseEntity<Employee> putResponse = updateEmployee(TENANT_ID, updatedEmployee);
         assertThat(putResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         response = getEmployee(TENANT_ID, putResponse.getBody().getId());

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeServiceTest.java
@@ -320,7 +320,7 @@ public class EmployeeServiceTest extends AbstractEntityRequireTenantRestServiceT
         String body = (new ObjectMapper()).writeValueAsString(updatedEmployee);
 
         mvc.perform(MockMvcRequestBuilders
-                .put("/rest/tenant/{tenantId}/employee/update", TENANT_ID)
+                .post("/rest/tenant/{tenantId}/employee/update", TENANT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body)
                 .accept(MediaType.APPLICATION_JSON))
@@ -351,7 +351,7 @@ public class EmployeeServiceTest extends AbstractEntityRequireTenantRestServiceT
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/employee/update", 0)
+                        .post("/rest/tenant/{tenantId}/employee/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: " +
@@ -369,7 +369,7 @@ public class EmployeeServiceTest extends AbstractEntityRequireTenantRestServiceT
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/employee/update", TENANT_ID)
+                        .post("/rest/tenant/{tenantId}/employee/update", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
@@ -397,7 +397,7 @@ public class EmployeeServiceTest extends AbstractEntityRequireTenantRestServiceT
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/employee/update", 0)
+                        .post("/rest/tenant/{tenantId}/employee/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalState" +

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.rotation.view.ShiftTemplateView;
+import org.optaweb.employeerostering.domain.shift.view.ShiftView;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.domain.tenant.Tenant;
@@ -50,8 +51,7 @@ public class RosterGeneratorTest {
     private final String employeePathURI = "http://localhost:8080/rest/tenant/{tenantId}/employee/";
     private final String rotationPathURI = "http://localhost:8080/rest/tenant/{tenantId}/rotation/";
     private final String tenantPathURI = "http://localhost:8080/rest/tenant/";
-    private final String employeeAvailabilityPathURI
-            = "http://localhost:8080/rest/tenant/{tenantId}/employee/availability/";
+    private final String shiftPathURI = "http://localhost:8080/rest/tenant/{tenantId}/shift/";
 
     private ResponseEntity<List<Skill>> getSkills(Integer tenantId) {
         return restTemplate.exchange(skillPathURI, HttpMethod.GET, null,
@@ -76,6 +76,11 @@ public class RosterGeneratorTest {
     private ResponseEntity<List<ShiftTemplateView>> getShiftTemplates(Integer tenantId) {
         return restTemplate.exchange(rotationPathURI, HttpMethod.GET, null,
                                      new ParameterizedTypeReference<List<ShiftTemplateView>>() {}, tenantId);
+    }
+
+    private ResponseEntity<List<ShiftView>> getShifts(Integer tenantId) {
+        return restTemplate.exchange(shiftPathURI, HttpMethod.GET, null,
+                                     new ParameterizedTypeReference<List<ShiftView>>() {}, tenantId);
     }
 
     private ResponseEntity<List<Tenant>> getTenants() {
@@ -143,13 +148,19 @@ public class RosterGeneratorTest {
     }
 
     @Test
+    public void generateShiftListTest() {
+        ResponseEntity<List<ShiftView>> response = getShifts(1);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get(0).getStartDateTime().toString()).isEqualTo("2019-08-12T06:00");
+        assertThat(response.getBody().get(0).getEndDateTime().toString()).isEqualTo("2019-08-12T14:00");
+    }
+
+    @Test
     public void generateTenantListTest() {
         ResponseEntity<List<Tenant>> response = getTenants();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().get(0).getName()).isEqualTo("Hospital Los Angeles (98 employees)");
     }
-
-    // TODO: Add tests for generating Shift entities once CRUD methods are implemented
-
 }

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
@@ -152,8 +152,6 @@ public class RosterGeneratorTest {
         ResponseEntity<List<ShiftView>> response = getShifts(1);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().get(0).getStartDateTime().toString()).isEqualTo("2019-08-19T06:00");
-        assertThat(response.getBody().get(0).getEndDateTime().toString()).isEqualTo("2019-08-19T14:00");
     }
 
     @Test

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
@@ -152,8 +152,8 @@ public class RosterGeneratorTest {
         ResponseEntity<List<ShiftView>> response = getShifts(1);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().get(0).getStartDateTime().toString()).isEqualTo("2019-08-12T06:00");
-        assertThat(response.getBody().get(0).getEndDateTime().toString()).isEqualTo("2019-08-12T14:00");
+        assertThat(response.getBody().get(0).getStartDateTime().toString()).isEqualTo("2019-08-19T06:00");
+        assertThat(response.getBody().get(0).getEndDateTime().toString()).isEqualTo("2019-08-19T14:00");
     }
 
     @Test

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
@@ -81,8 +81,8 @@ public class RosterRestControllerTest extends AbstractEntityRequireTenantRestSer
                                                                Integer numberOfItemsPerPage, String startDateString,
                                                                String endDateString) {
         UriComponents uriComponents = UriComponentsBuilder.fromUriString(rosterPathURI + "shiftRosterView")
-                .queryParam("pageNumber", pageNumber)
-                .queryParam("numberOfItemsPerPage", numberOfItemsPerPage)
+                .queryParam("p", pageNumber)
+                .queryParam("n", numberOfItemsPerPage)
                 .queryParam("startDate", startDateString)
                 .queryParam("endDate", endDateString)
                 .build()
@@ -96,8 +96,8 @@ public class RosterRestControllerTest extends AbstractEntityRequireTenantRestSer
                                                                              String startDateString,
                                                                              String endDateString) {
         UriComponents uriComponents = UriComponentsBuilder.fromUriString(rosterPathURI + "availabilityRosterView")
-                .queryParam("pageNumber", pageNumber)
-                .queryParam("numberOfItemsPerPage", numberOfItemsPerPage)
+                .queryParam("p", pageNumber)
+                .queryParam("n", numberOfItemsPerPage)
                 .queryParam("startDate", startDateString)
                 .queryParam("endDate", endDateString)
                 .build()

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
@@ -33,6 +33,7 @@ import org.optaweb.employeerostering.domain.contract.view.ContractView;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.employee.EmployeeAvailabilityState;
 import org.optaweb.employeerostering.domain.employee.view.EmployeeAvailabilityView;
+import org.optaweb.employeerostering.domain.roster.PublishResult;
 import org.optaweb.employeerostering.domain.roster.RosterState;
 import org.optaweb.employeerostering.domain.roster.view.AvailabilityRosterView;
 import org.optaweb.employeerostering.domain.roster.view.RosterStateView;
@@ -104,6 +105,10 @@ public class RosterRestControllerTest extends AbstractEntityRequireTenantRestSer
                 .expand(Collections.singletonMap("tenantId", TENANT_ID));
 
         return restTemplate.getForEntity(uriComponents.toUriString(), AvailabilityRosterView.class);
+    }
+
+    private ResponseEntity<PublishResult> publishAndProvision() {
+        return restTemplate.postForEntity(rosterPathURI + "publishAndProvision", null, PublishResult.class, TENANT_ID);
     }
 
     private Spot addSpot(String name) {
@@ -266,5 +271,15 @@ public class RosterRestControllerTest extends AbstractEntityRequireTenantRestSer
         assertThat(availabilityRosterView.getEmployeeIdToShiftViewListMap()).containsOnly(
                 entry(employeeList.get(1).getId(), Arrays.asList(shiftViewList.get(1))));
         assertThat(availabilityRosterView.getTenantId()).isEqualTo(TENANT_ID);
+    }
+
+    @Test
+    public void testPublishAndProvision() {
+        createTestRoster();
+
+        ResponseEntity<PublishResult> publishResultResponseEntity = publishAndProvision();
+        assertThat(publishResultResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(publishResultResponseEntity.getBody().getPublishedFromDate()).isEqualTo("2000-01-01");
+        assertThat(publishResultResponseEntity.getBody().getPublishedToDate()).isEqualTo("2000-01-08");
     }
 }

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftRestControllerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.shift;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
+import org.optaweb.employeerostering.domain.contract.Contract;
+import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.shift.view.ShiftView;
+import org.optaweb.employeerostering.domain.spot.Spot;
+import org.optaweb.employeerostering.domain.spot.view.SpotView;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class ShiftRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private final String shiftPathURI = "http://localhost:8080/rest/tenant/{tenantId}/shift/";
+    private final String employeePathURI = "http://localhost:8080/rest/tenant/{tenantId}/employee/";
+    private final String contractPathURI = "http://localhost:8080/rest/tenant/{tenantId}/contract/";
+    private final String spotPathURI = "http://localhost:8080/rest/tenant/{tenantId}/spot/";
+
+    private ResponseEntity<List<ShiftView>> getShifts(Integer tenantId) {
+        return restTemplate.exchange(shiftPathURI, HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<ShiftView>>() {
+                }, tenantId);
+    }
+
+    private ResponseEntity<ShiftView> getShift(Integer tenantId, Long id) {
+        return restTemplate.getForEntity(shiftPathURI + id, ShiftView.class, tenantId);
+    }
+
+    private void deleteShift(Integer tenantId, Long id) {
+        restTemplate.delete(shiftPathURI + id, tenantId);
+    }
+
+    private ResponseEntity<ShiftView> addShift(Integer tenantId, ShiftView shiftView) {
+        return restTemplate.postForEntity(shiftPathURI + "add", shiftView, ShiftView.class, tenantId);
+    }
+
+    private ResponseEntity<ShiftView> updateShift(Integer tenantId, HttpEntity<ShiftView> request) {
+        return restTemplate.exchange(shiftPathURI + "update", HttpMethod.PUT, request, ShiftView.class, tenantId);
+    }
+
+    private ResponseEntity<Employee> addEmployee(Integer tenantId, Employee employee) {
+        return restTemplate.postForEntity(employeePathURI + "add", employee, Employee.class, tenantId);
+    }
+
+    private ResponseEntity<Contract> addContract(Integer tenantId, Contract contract) {
+        return restTemplate.postForEntity(contractPathURI + "add", contract, Contract.class, tenantId);
+    }
+
+    private ResponseEntity<Spot> addSpot(Integer tenantId, SpotView spotView) {
+        return restTemplate.postForEntity(spotPathURI + "add", spotView, Spot.class, tenantId);
+    }
+
+    @Before
+    public void setup() {
+        createTestTenant();
+    }
+
+    @After
+    public void cleanup() {
+        deleteTestTenant();
+    }
+
+    @Test
+    public void shiftCrudTest() {
+        ResponseEntity<Spot> spotResponseEntity = addSpot(TENANT_ID, new SpotView(TENANT_ID, "spot",
+                Collections.emptySet()));
+        Spot spot = spotResponseEntity.getBody();
+
+        ResponseEntity<Contract> contractResponseEntity = addContract(TENANT_ID, new Contract(TENANT_ID, "contract"));
+        Contract contract = contractResponseEntity.getBody();
+
+        ResponseEntity<Employee> rotationEmployeeResponseEntity = addEmployee(TENANT_ID, new Employee(TENANT_ID,
+                "rotationEmployee", contract, Collections.emptySet()));
+        Employee rotationEmployee = rotationEmployeeResponseEntity.getBody();
+
+        LocalDateTime startDateTime = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0);
+        LocalDateTime endDateTime = startDateTime.plusHours(8);
+        ShiftView shiftView = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime, rotationEmployee);
+        ResponseEntity<ShiftView> postResponse = addShift(TENANT_ID, shiftView);
+        assertThat(postResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<ShiftView> getResponse = getShift(TENANT_ID, postResponse.getBody().getId());
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(getResponse.getBody()).isEqualToComparingFieldByFieldRecursively(postResponse.getBody());
+
+        ShiftView updatedShiftView = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime);
+        updatedShiftView.setId(postResponse.getBody().getId());
+        HttpEntity<ShiftView> request = new HttpEntity<>(updatedShiftView);
+        ResponseEntity<ShiftView> putResponse = updateShift(TENANT_ID, request);
+        assertThat(putResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        getResponse = getShift(TENANT_ID, putResponse.getBody().getId());
+        assertThat(putResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(putResponse.getBody()).isEqualToComparingFieldByFieldRecursively(getResponse.getBody());
+
+        deleteShift(TENANT_ID, putResponse.getBody().getId());
+
+        ResponseEntity<List<ShiftView>> getShiftListResponse = getShifts(TENANT_ID);
+        assertThat(getShiftListResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(getShiftListResponse.getBody()).isEmpty();
+    }
+}

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftServiceTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.shift;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
+import org.optaweb.employeerostering.domain.contract.Contract;
+import org.optaweb.employeerostering.domain.contract.view.ContractView;
+import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.employee.view.EmployeeView;
+import org.optaweb.employeerostering.domain.shift.view.ShiftView;
+import org.optaweb.employeerostering.domain.spot.Spot;
+import org.optaweb.employeerostering.domain.spot.view.SpotView;
+import org.optaweb.employeerostering.service.contract.ContractService;
+import org.optaweb.employeerostering.service.employee.EmployeeService;
+import org.optaweb.employeerostering.service.shift.ShiftService;
+import org.optaweb.employeerostering.service.spot.SpotService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.NestedServletException;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShiftServiceTest.class);
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ShiftService shiftService;
+
+    @Autowired
+    private SpotService spotService;
+
+    @Autowired
+    private ContractService contractService;
+
+    @Autowired
+    private EmployeeService employeeService;
+
+    private Spot createSpot(Integer tenantId, String name) {
+        SpotView spotView = new SpotView(tenantId, name, Collections.emptySet());
+        return spotService.createSpot(tenantId, spotView);
+    }
+
+    private Contract createContract(Integer tenantId, String name) {
+        ContractView contractView = new ContractView(tenantId, name);
+        return contractService.createContract(tenantId, contractView);
+    }
+
+    private Employee createEmployee(Integer tenantId, String name, Contract contract) {
+        EmployeeView employeeView = new EmployeeView(tenantId, name, contract, Collections.emptySet());
+        return employeeService.createEmployee(tenantId, employeeView);
+    }
+
+    @Before
+    public void setup() {
+        createTestTenant();
+    }
+
+    @After
+    public void cleanup() {
+        deleteTestTenant();
+    }
+
+    @Test
+    public void getShiftListTest() throws Exception {
+        mvc.perform(MockMvcRequestBuilders
+                .get("/rest/tenant/{tenantId}/shift/", TENANT_ID)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getShiftTest() throws Exception {
+        Spot spot = createSpot(TENANT_ID, "spot");
+        Contract contract = createContract(TENANT_ID, "contract");
+        Employee rotationEmployee = createEmployee(TENANT_ID, "rotationEmployee", contract);
+
+        LocalDateTime startDateTime = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0);
+        LocalDateTime endDateTime = startDateTime.plusHours(8);
+        ShiftView shiftView = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime, rotationEmployee);
+        ShiftView persistedShift = shiftService.createShift(TENANT_ID, shiftView);
+
+        mvc.perform(MockMvcRequestBuilders
+                .get("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, persistedShift.getId())
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.rotationEmployeeId").value(
+                        persistedShift.getRotationEmployeeId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.spotId").value(persistedShift.getSpotId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.startDateTime").value(
+                        "2000-01-01T00:00:00"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.endDateTime").value(
+                        "2000-01-01T08:00:00"));
+    }
+
+    @Test
+    public void getNonExistentShiftTest() {
+        assertThatExceptionOfType(NestedServletException.class)
+                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
+                        .get("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, 0)))
+                .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
+                        "Exception: No Shift entity found with ID (0).");
+    }
+
+    @Test
+    public void deleteShiftTest() throws Exception {
+        Spot spot = createSpot(TENANT_ID, "spot");
+        Contract contract = createContract(TENANT_ID, "contract");
+        Employee rotationEmployee = createEmployee(TENANT_ID, "rotationEmployee", contract);
+
+        LocalDateTime startDateTime = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0);
+        LocalDateTime endDateTime = startDateTime.plusHours(8);
+        ShiftView shiftView = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime, rotationEmployee);
+        ShiftView persistedShift = shiftService.createShift(TENANT_ID, shiftView);
+
+        mvc.perform(MockMvcRequestBuilders
+                .delete("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, persistedShift.getId())
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    public void deleteNonExistentShiftTest() throws Exception {
+        mvc.perform(MockMvcRequestBuilders
+                .delete("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, 0)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    public void createShiftTest() throws Exception {
+        Spot spot = createSpot(TENANT_ID, "spot");
+        Contract contract = createContract(TENANT_ID, "contract");
+        Employee rotationEmployee = createEmployee(TENANT_ID, "rotationEmployee", contract);
+
+        LocalDateTime startDateTime = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0);
+        LocalDateTime endDateTime = startDateTime.plusHours(8);
+        ShiftView shiftView = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime, rotationEmployee);
+        String body = (new ObjectMapper()).writeValueAsString(shiftView);
+
+        mvc.perform(MockMvcRequestBuilders
+                .post("/rest/tenant/{tenantId}/shift/add", TENANT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.rotationEmployeeId").value(
+                        shiftView.getRotationEmployeeId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.spotId").value(shiftView.getSpotId()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.startDateTime").value(
+                        "2000-01-01T00:00:00"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.endDateTime").value(
+                        "2000-01-01T08:00:00"));
+    }
+
+    @Test
+    public void updateShiftTest() throws Exception {
+        Spot spot = createSpot(TENANT_ID, "spot");
+        Contract contract = createContract(TENANT_ID, "contract");
+        Employee rotationEmployee = createEmployee(TENANT_ID, "rotationEmployee", contract);
+
+        LocalDateTime startDateTime = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0);
+        LocalDateTime endDateTime = startDateTime.plusHours(8);
+        ShiftView shiftView = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime, rotationEmployee);
+        ShiftView persistedShift = shiftService.createShift(TENANT_ID, shiftView);
+
+        startDateTime = LocalDateTime.of(1999, 12, 31, 23, 59, 59, 0);
+        endDateTime = startDateTime.plusHours(10);
+        ShiftView updatedShift = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime, rotationEmployee);
+        updatedShift.setId(persistedShift.getId());
+        String body = (new ObjectMapper()).writeValueAsString(updatedShift);
+
+        mvc.perform(MockMvcRequestBuilders
+                .put("/rest/tenant/{tenantId}/shift/update", TENANT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.startDateTime").value(
+                        "1999-12-31T23:59:59"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.endDateTime").value(
+                        "2000-01-01T09:59:59"));
+    }
+
+    @Test
+    public void updateNonExistentShiftTest() throws Exception {
+        Spot spot = createSpot(TENANT_ID, "spot");
+        LocalDateTime startDateTime = LocalDateTime.of(1999, 12, 31, 23, 59, 59, 0);
+        LocalDateTime endDateTime = startDateTime.plusHours(10);
+        ShiftView updatedShift = new ShiftView(TENANT_ID, spot, startDateTime, endDateTime);
+        updatedShift.setId(0L);
+        String body = (new ObjectMapper()).writeValueAsString(updatedShift);
+
+        assertThatExceptionOfType(NestedServletException.class)
+                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
+                        .put("/rest/tenant/{tenantId}/shift/update", TENANT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)))
+                .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
+                        "Exception: Shift entity with ID (0) not found.");
+    }
+}

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillRestControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -64,8 +63,8 @@ public class SkillRestControllerTest extends AbstractEntityRequireTenantRestServ
         return restTemplate.postForEntity(skillPathURI + "add", skillView, Skill.class, tenantId);
     }
 
-    private ResponseEntity<Skill> updateSkill(Integer tenantId, HttpEntity<SkillView> request) {
-        return restTemplate.exchange(skillPathURI + "update", HttpMethod.PUT, request, Skill.class, tenantId);
+    private ResponseEntity<Skill> updateSkill(Integer tenantId, SkillView skillView) {
+        return restTemplate.postForEntity(skillPathURI + "update", skillView, Skill.class, tenantId);
     }
 
     @Before
@@ -90,8 +89,7 @@ public class SkillRestControllerTest extends AbstractEntityRequireTenantRestServ
 
         SkillView updatedSkill = new SkillView(TENANT_ID, "updatedSkill");
         updatedSkill.setId(postResponse.getBody().getId());
-        HttpEntity<SkillView> request = new HttpEntity<>(updatedSkill);
-        ResponseEntity<Skill> putResponse = updateSkill(TENANT_ID, request);
+        ResponseEntity<Skill> putResponse = updateSkill(TENANT_ID, updatedSkill);
         assertThat(putResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         response = getSkill(TENANT_ID, putResponse.getBody().getId());

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillServiceTest.java
@@ -189,7 +189,7 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
         String body = (new ObjectMapper()).writeValueAsString(updatedSkill);
 
         mvc.perform(MockMvcRequestBuilders
-                .put("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
+                .post("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body)
                 .accept(MediaType.APPLICATION_JSON))
@@ -209,7 +209,7 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/skill/update", 0)
+                        .post("/rest/tenant/{tenantId}/skill/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: "
@@ -225,7 +225,7 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
+                        .post("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
@@ -243,7 +243,7 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/skill/update", 0)
+                        .post("/rest/tenant/{tenantId}/skill/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalState" +

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/SolverManagerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/SolverManagerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.solver;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaweb.employeerostering.domain.roster.Roster;
+import org.optaweb.employeerostering.service.roster.RosterGenerator;
+import org.optaweb.employeerostering.service.roster.RosterService;
+import org.optaweb.employeerostering.service.solver.WannabeSolverManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class SolverManagerTest {
+
+    @Autowired
+    private ThreadPoolTaskExecutor taskExecutor;
+
+    @Autowired
+    private RosterService rosterService;
+
+    @Autowired
+    private RosterGenerator rosterGenerator;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    public void testSolverManager() throws InterruptedException {
+        WannabeSolverManager solverManager = new WannabeSolverManager(taskExecutor, rosterService);
+        solverManager.setUpSolverFactory();
+
+        Roster roster = rosterGenerator.generateRoster(10, 7);
+
+        CountDownLatch solverEndedLatch = solverManager.solve(roster.getTenantId());
+
+        solverEndedLatch.await();
+        ScoreDirector<Roster> scoreDirector = solverManager.getScoreDirector();
+        scoreDirector.setWorkingSolution(roster);
+        roster.setScore((HardMediumSoftLongScore) scoreDirector.calculateScore());
+        assertNotNull(roster.getScore());
+        // Due to overconstrained planning, the score is always feasible
+        assertTrue(roster.getScore().isFeasible());
+        assertFalse(roster.getShiftList().isEmpty());
+        assertTrue(roster.getShiftList().stream().anyMatch(s -> s.getEmployee() != null));
+    }
+}

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/SolverTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/SolverTest.java
@@ -1,0 +1,722 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.solver;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.persistence.EntityManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+import org.optaplanner.core.api.solver.Solver;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+import org.optaplanner.test.impl.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreVerifier;
+import org.optaweb.employeerostering.domain.common.AbstractPersistable;
+import org.optaweb.employeerostering.domain.contract.Contract;
+import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
+import org.optaweb.employeerostering.domain.employee.EmployeeAvailabilityState;
+import org.optaweb.employeerostering.domain.roster.Roster;
+import org.optaweb.employeerostering.domain.roster.RosterState;
+import org.optaweb.employeerostering.domain.shift.Shift;
+import org.optaweb.employeerostering.domain.skill.Skill;
+import org.optaweb.employeerostering.domain.spot.Spot;
+import org.optaweb.employeerostering.domain.tenant.RosterParametrization;
+import org.optaweb.employeerostering.domain.tenant.Tenant;
+import org.optaweb.employeerostering.service.roster.RosterGenerator;
+import org.optaweb.employeerostering.service.solver.WannabeSolverManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class SolverTest {
+
+    private static final int TENANT_ID = 0;
+    private static final LocalDate START_DATE = LocalDate.of(2019, 5, 13);
+    private static final RosterParametrization ROSTER_PARAMETRIZATION = new RosterParametrization();
+
+    private SolverFactory<Roster> getSolverFactory() {
+        SolverFactory<Roster> solverFactory = SolverFactory.createFromXmlResource(WannabeSolverManager.SOLVER_CONFIG);
+        solverFactory.getSolverConfig().setTerminationConfig(new TerminationConfig()
+                                                                     .withScoreCalculationCountLimit(10000L));
+        return solverFactory;
+    }
+
+    private HardMediumSoftLongScoreVerifier<Roster> getScoreVerifier() {
+        return new HardMediumSoftLongScoreVerifier<Roster>(getSolverFactory());
+    }
+
+    // A solver "integration" test that verify that our constraints can create a feasible
+    // solution on our demo data set
+    @Test(timeout = 600000)
+    public void testFeasibleSolution() {
+        Solver<Roster> solver = getSolverFactory().buildSolver();
+
+        RosterGenerator rosterGenerator = buildRosterGenerator();
+        Roster roster = rosterGenerator.generateRoster(10, 7);
+
+        roster = solver.solve(roster);
+        assertNotNull(roster.getScore());
+        // Due to overconstrained planning, the score is always feasible
+        assertTrue(roster.getScore().isFeasible());
+        assertFalse(roster.getShiftList().isEmpty());
+        assertTrue(roster.getShiftList().stream().anyMatch(s -> s.getEmployee() != null));
+    }
+
+    private void testContractConstraint(ContractField contractField) {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Contract contract = contractField.getContract(idGenerator);
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+
+        employeeA.setId(idGenerator.getAndIncrement());
+        Spot spotA = new Spot(TENANT_ID, "Spot", Collections.emptySet());
+        spotA.setId(idGenerator.getAndIncrement());
+
+        LocalDate firstDayOfWeek = START_DATE.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        OffsetDateTime firstDateTime = OffsetDateTime.of(firstDayOfWeek, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+
+        ShiftBuilder shiftBuilder = new ShiftBuilder(idGenerator)
+                .forSpot(spotA)
+                .startingAtDate(firstDateTime)
+                .withShiftLength(Duration.ofHours(1));
+
+        List<Shift> shiftList = contractField.generateShifts(shiftBuilder);
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Collections.emptyList());
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.emptyList());
+        roster.setShiftList(shiftList);
+
+        shiftList.get(0).setEmployee(employeeA);
+        shiftList.get(1).setEmployee(employeeA);
+
+        shiftList.get(3).setEmployee(employeeA);
+        shiftList.get(4).setEmployee(employeeA);
+
+        Constraints constraint = contractField.getConstraint();
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+
+        shiftList.get(2).setEmployee(employeeA);
+
+        // -1 for each shift in overloaded week
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 3);
+
+        shiftList.get(5).setEmployee(employeeA);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 6);
+
+        shiftList.get(1).setEmployee(null);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 3);
+    }
+
+    @Test(timeout = 600000)
+    public void testContractConstraints() {
+        for (ContractField field : ContractField.values()) {
+            testContractConstraint(field);
+        }
+    }
+
+    @Test(timeout = 600000)
+    public void testRequiredSkillForShiftConstraint() {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Skill skillA = new Skill(TENANT_ID, "Skill A");
+        Skill skillB = new Skill(TENANT_ID, "Skill B");
+        skillA.setId(idGenerator.getAndIncrement());
+        skillB.setId(idGenerator.getAndIncrement());
+
+        Spot spotA = new Spot(TENANT_ID, "Spot A", new HashSet<>(Arrays.asList(skillA, skillB)));
+        spotA.setId(idGenerator.getAndIncrement());
+
+        Contract contract = getDefaultContract(idGenerator);
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+        employeeA.setId(idGenerator.getAndIncrement());
+
+        OffsetDateTime firstDateTime = OffsetDateTime.of(START_DATE, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        Shift shift = new Shift(TENANT_ID, spotA, firstDateTime, firstDateTime.plusHours(9));
+        shift.setId(idGenerator.getAndIncrement());
+        shift.setEmployee(employeeA);
+
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Arrays.asList(skillA, skillB));
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.emptyList());
+        roster.setShiftList(Collections.singletonList(shift));
+
+        final Constraints constraint = Constraints.REQUIRED_SKILL_FOR_A_SHIFT;
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        employeeA.setSkillProficiencySet(new HashSet<>(Collections.singleton(skillA)));
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        employeeA.setSkillProficiencySet(new HashSet<>(Collections.singleton(skillB)));
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        employeeA.setSkillProficiencySet(new HashSet<>(Arrays.asList(skillA, skillB)));
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+    }
+
+    private void testAvailabilityConstraint(EmployeeAvailabilityState availabilityState) {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Contract contract = getDefaultContract(idGenerator);
+
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+        employeeA.setId(idGenerator.getAndIncrement());
+
+        Spot spotA = new Spot(TENANT_ID, "Spot", Collections.emptySet());
+        spotA.setId(idGenerator.getAndIncrement());
+
+        OffsetDateTime firstDateTime = OffsetDateTime.of(START_DATE, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        Shift shift = new Shift(TENANT_ID, spotA, firstDateTime, firstDateTime.plusHours(9));
+        shift.setId(idGenerator.getAndIncrement());
+        shift.setEmployee(employeeA);
+
+        EmployeeAvailability availability = new EmployeeAvailability(TENANT_ID, employeeA, firstDateTime,
+                                                                     firstDateTime.plusHours(9));
+        availability.setId(idGenerator.getAndIncrement());
+        availability.setState(availabilityState);
+
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Collections.emptyList());
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.singletonList(availability));
+        roster.setShiftList(Collections.singletonList(shift));
+
+        Constraints constraint;
+
+        switch (availabilityState) {
+            case DESIRED:
+                constraint = Constraints.DESIRED_TIME_SLOT_FOR_AN_EMPLOYEE;
+                break;
+
+            case UNDESIRED:
+                constraint = Constraints.UNDESIRED_TIME_SLOT_FOR_AN_EMPLOYEE;
+                break;
+
+            case UNAVAILABLE:
+                constraint = Constraints.UNAVAILABLE_TIME_SLOT_FOR_AN_EMPLOYEE;
+                break;
+
+            default:
+                throw new IllegalArgumentException("No case for (" + availabilityState + ")");
+        }
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shift.setStartDateTime(firstDateTime.minusHours(3));
+        shift.setEndDateTime(firstDateTime.plusHours(6));
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shift.setStartDateTime(firstDateTime.plusHours(3));
+        shift.setEndDateTime(firstDateTime.plusHours(12));
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shift.setStartDateTime(firstDateTime.plusHours(12));
+        shift.setEndDateTime(firstDateTime.plusHours(21));
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+    }
+
+    @Test(timeout = 600000)
+    public void testEmployeeAvilabilityConstraints() {
+        for (EmployeeAvailabilityState state : EmployeeAvailabilityState.values()) {
+            testAvailabilityConstraint(state);
+        }
+    }
+
+    @Test(timeout = 600000)
+    public void testAtMostOneShiftAssignmentPerDayPerEmployee() {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Contract contract = getDefaultContract(idGenerator);
+
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+        employeeA.setId(idGenerator.getAndIncrement());
+
+        Spot spotA = new Spot(TENANT_ID, "Spot", Collections.emptySet());
+        spotA.setId(idGenerator.getAndIncrement());
+
+        OffsetDateTime firstDateTime = OffsetDateTime.of(START_DATE, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        ShiftBuilder shiftBuilder = new ShiftBuilder(idGenerator)
+                .forSpot(spotA)
+                .startingAtDate(firstDateTime)
+                .withShiftLength(Duration.ofHours(1))
+                .withTimeBetweenShifts(Duration.ofHours(1));
+
+        List<Shift> shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Collections.emptyList());
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.emptyList());
+        roster.setShiftList(shiftList);
+
+        final Constraints constraint = Constraints.AT_MOST_ONE_SHIFT_ASSIGNMENT_PER_DAY_PER_EMPLOYEE;
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 2);
+
+        shiftBuilder.withTimeBetweenShifts(Duration.ofDays(1));
+        shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+        roster.setShiftList(shiftList);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+
+        // Start time is midnight, so one hour before is a different day
+        shiftBuilder.withTimeBetweenShifts(Duration.ofHours(-1));
+        shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+        roster.setShiftList(shiftList);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+    }
+
+    @Test(timeout = 600000)
+    public void testNoTwoShiftsWithin10HoursOfEachOther() {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Contract contract = getDefaultContract(idGenerator);
+
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+        employeeA.setId(idGenerator.getAndIncrement());
+
+        Spot spotA = new Spot(TENANT_ID, "Spot", Collections.emptySet());
+        spotA.setId(idGenerator.getAndIncrement());
+
+        OffsetDateTime firstDateTime = OffsetDateTime.of(START_DATE, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        ShiftBuilder shiftBuilder = new ShiftBuilder(idGenerator)
+                .forSpot(spotA)
+                .startingAtDate(firstDateTime)
+                .withShiftLength(Duration.ofHours(1))
+                .withTimeBetweenShifts(Duration.ofHours(1));
+
+        List<Shift> shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Collections.emptyList());
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.emptyList());
+        roster.setShiftList(shiftList);
+
+        final Constraints constraint = Constraints.NO_2_SHIFTS_WITHIN_10_HOURS_FROM_EACH_OTHER;
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shiftBuilder.withTimeBetweenShifts(Duration.ofHours(10));
+        shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+        roster.setShiftList(shiftList);
+
+        // Although start times are 10 hours apart, first end time is 9 hours apart
+        // from next start time
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shiftBuilder.withTimeBetweenShifts(Duration.ofHours(11));
+        shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+        roster.setShiftList(shiftList);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+
+        // Start time is midnight, so one hour before is a different day
+        shiftBuilder.withTimeBetweenShifts(Duration.ofHours(-1));
+        shiftList = shiftBuilder.generateShifts(2);
+        shiftList.forEach(s -> s.setEmployee(employeeA));
+        roster.setShiftList(shiftList);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+    }
+
+    @Test(timeout = 600000)
+    public void testAssignEveryShift() {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Contract contract = getDefaultContract(idGenerator);
+
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+        employeeA.setId(idGenerator.getAndIncrement());
+
+        Spot spotA = new Spot(TENANT_ID, "Spot", Collections.emptySet());
+        spotA.setId(idGenerator.getAndIncrement());
+
+        OffsetDateTime firstDateTime = OffsetDateTime.of(START_DATE, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        ShiftBuilder shiftBuilder = new ShiftBuilder(idGenerator)
+                .forSpot(spotA)
+                .startingAtDate(firstDateTime)
+                .withShiftLength(Duration.ofHours(1))
+                .withTimeBetweenShifts(Duration.ofDays(1));
+
+        List<Shift> shiftList = shiftBuilder.generateShifts(3);
+
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Collections.emptyList());
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.emptyList());
+        roster.setShiftList(shiftList);
+
+        final Constraints constraint = Constraints.ASSIGN_EVERY_SHIFT;
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 3);
+
+        shiftList.get(0).setEmployee(employeeA);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 2);
+
+        shiftList.get(1).setEmployee(employeeA);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shiftList.get(2).setEmployee(employeeA);
+
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+    }
+
+    @Test(timeout = 600000)
+    public void testEmployeeIsNotRotationEmployeeConstraint() {
+        HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
+
+        AtomicLong idGenerator = new AtomicLong(1L);
+
+        Roster roster = new Roster();
+        Tenant tenant = new Tenant("Test Tenant");
+        tenant.setId(TENANT_ID);
+
+        RosterState rosterState = getRosterState(idGenerator);
+        RosterParametrization rosterParametrization = getRosterParametrization(idGenerator);
+
+        Spot spotA = new Spot(TENANT_ID, "Spot A", Collections.emptySet());
+        spotA.setId(idGenerator.getAndIncrement());
+
+        Contract contract = getDefaultContract(idGenerator);
+        Employee employeeA = new Employee(TENANT_ID, "Bill", contract, Collections.emptySet());
+        employeeA.setId(idGenerator.getAndIncrement());
+        Employee rotationEmployee = new Employee(TENANT_ID, "Anna", contract, Collections.emptySet());
+        rotationEmployee.setId(idGenerator.getAndIncrement());
+
+        OffsetDateTime firstDateTime = OffsetDateTime.of(START_DATE, LocalTime.MIDNIGHT, ZoneOffset.UTC);
+        Shift shift = new Shift(TENANT_ID, spotA, firstDateTime, firstDateTime.plusHours(9));
+        shift.setId(idGenerator.getAndIncrement());
+        shift.setEmployee(employeeA);
+        shift.setRotationEmployee(rotationEmployee);
+
+        roster.setTenantId(TENANT_ID);
+        roster.setRosterState(rosterState);
+        roster.setSpotList(Collections.singletonList(spotA));
+        roster.setEmployeeList(Collections.singletonList(employeeA));
+        roster.setSkillList(Collections.emptyList());
+        roster.setRosterParametrization(rosterParametrization);
+        roster.setEmployeeAvailabilityList(Collections.emptyList());
+        roster.setShiftList(Collections.singletonList(shift));
+
+        final Constraints constraint = Constraints.EMPLOYEE_IS_NOT_ROTATION_EMPLOYEE;
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+
+        shift.setEmployee(rotationEmployee);
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+    }
+
+    protected RosterGenerator buildRosterGenerator() {
+        EntityManager entityManager = mock(EntityManager.class);
+        AtomicInteger tenantIdGenerator = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            Tenant tenant = (Tenant) invocation.getArgument(0);
+            tenant.setId(tenantIdGenerator.getAndIncrement());
+            return invocation;
+        }).when(entityManager).persist(any(Tenant.class));
+        AtomicLong idGenerator = new AtomicLong(0L);
+        doAnswer(invocation -> {
+            AbstractPersistable o = (AbstractPersistable) invocation.getArgument(0);
+            o.setId(idGenerator.getAndIncrement());
+            return invocation;
+        }).when(entityManager).persist(any(AbstractPersistable.class));
+
+        RosterGenerator rosterGenerator = new RosterGenerator(entityManager);
+        rosterGenerator.setUpGeneratedData();
+        return rosterGenerator;
+    }
+
+    private RosterState getRosterState(AtomicLong idGenerator) {
+        final int PUBLISH_NOTICE = 7;
+        final int PUBLISH_LENGTH = 7;
+        final int DRAFT_LENGTH = 14;
+        final int ROTATION_OFFSET = 0;
+        final int ROTATION_LENGTH = 7;
+
+        RosterState rosterState = new RosterState(TENANT_ID, PUBLISH_NOTICE, START_DATE.minusDays(PUBLISH_NOTICE),
+                                                  PUBLISH_LENGTH, DRAFT_LENGTH, ROTATION_OFFSET, ROTATION_LENGTH,
+                                                  START_DATE.minusDays(2 * PUBLISH_NOTICE), ZoneId.systemDefault());
+        rosterState.setId(idGenerator.getAndIncrement());
+        return rosterState;
+    }
+
+    private Contract getDefaultContract(AtomicLong idGenerator) {
+        Contract out = new Contract(TENANT_ID, "Default Contract", null, null, null, null);
+        out.setId(idGenerator.getAndIncrement());
+        return out;
+    }
+
+    private RosterParametrization getRosterParametrization(AtomicLong idGenerator) {
+        ROSTER_PARAMETRIZATION.setTenantId(TENANT_ID);
+        ROSTER_PARAMETRIZATION.setId(idGenerator.getAndIncrement());
+        ROSTER_PARAMETRIZATION.setWeekStartDay(DayOfWeek.MONDAY);
+        return ROSTER_PARAMETRIZATION;
+    }
+
+    private enum Constraints {
+        REQUIRED_SKILL_FOR_A_SHIFT("Required skill for a shift",
+                                   HardMediumSoftScore.of(-100, 0, 0)),
+        UNAVAILABLE_TIME_SLOT_FOR_AN_EMPLOYEE("Unavailable time slot for an employee",
+                                              HardMediumSoftScore.of(-50, 0, 0)),
+        AT_MOST_ONE_SHIFT_ASSIGNMENT_PER_DAY_PER_EMPLOYEE("At most one shift assignment per day per employee",
+                                                          HardMediumSoftScore.of(-10, 0, 0)),
+        NO_2_SHIFTS_WITHIN_10_HOURS_FROM_EACH_OTHER("No 2 shifts within 10 hours from each other",
+                                                    HardMediumSoftScore.of(-1, 0, 0)),
+        DAILY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM("Daily minutes must not exceed contract maximum",
+                                                       HardMediumSoftScore.of(-1, 0, 0)),
+        WEEKLY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM("Weekly minutes must not exceed contract maximum",
+                                                        HardMediumSoftScore.of(-1, 0, 0)),
+        MONTHLY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM("Monthly minutes must not exceed contract maximum",
+                                                         HardMediumSoftScore.of(-1, 0, 0)),
+        YEARLY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM("Yearly minutes must not exceed contract maximum",
+                                                        HardMediumSoftScore.of(-1, 0, 0)),
+        ASSIGN_EVERY_SHIFT("Assign every shift", HardMediumSoftScore.of(0, -1, 0)),
+        UNDESIRED_TIME_SLOT_FOR_AN_EMPLOYEE("Undesired time slot for an employee",
+                                            HardMediumSoftScore.of(0, 0, -ROSTER_PARAMETRIZATION.
+                                                    getUndesiredTimeSlotWeight())),
+        DESIRED_TIME_SLOT_FOR_AN_EMPLOYEE("Desired time slot for an employee",
+                                          HardMediumSoftScore.of(0, 0, ROSTER_PARAMETRIZATION
+                                                  .getDesiredTimeSlotWeight())),
+        EMPLOYEE_IS_NOT_ROTATION_EMPLOYEE("Employee is not rotation employee",
+                                          HardMediumSoftScore.of(0, 0, -ROSTER_PARAMETRIZATION
+                                                  .getRotationEmployeeMatchWeight()));
+
+        String constraintName;
+        HardMediumSoftScore constraintWeight;
+
+        private Constraints(String constraintName, HardMediumSoftScore constraintWeight) {
+            this.constraintName = constraintName;
+            this.constraintWeight = constraintWeight;
+        }
+
+        public void verifyNumOfInstances(HardMediumSoftLongScoreVerifier<Roster> scoreVerifier, Roster roster,
+                                         int numOfInstances) {
+            scoreVerifier.assertHardWeight(constraintName, constraintWeight.getHardScore() * numOfInstances, roster);
+            scoreVerifier.assertMediumWeight(constraintName, constraintWeight.getMediumScore() * numOfInstances,
+                                             roster);
+            scoreVerifier.assertSoftWeight(constraintName, constraintWeight.getSoftScore() * numOfInstances, roster);
+        }
+    }
+
+    private enum ContractField {
+        DAILY(Constraints.DAILY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM, 2 * 60, null, null, null,
+              Duration.ofHours(6), Duration.ofDays(1)),
+        WEEKLY(Constraints.WEEKLY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM, null, 2 * 60, null, null,
+               Duration.ofDays(1), Duration.ofDays(7)),
+        MONTHLY(Constraints.MONTHLY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM, null, null, 2 * 60, null,
+                Duration.ofDays(7), Duration.ofDays(31)),
+        ANNUALLY(Constraints.YEARLY_MINUTES_MUST_NOT_EXCEED_CONTRACT_MAXIMUM, null, null, null, 2 * 60,
+                 Duration.ofDays(31), Duration.ofDays(366));
+
+        Constraints constraint;
+        Integer dailyHours, weeklyHours, monthlyHours, yearlyHours;
+        Duration timeBetweenShifts, periodLength;
+
+        private ContractField(Constraints constraint, Integer dailyHours, Integer weeklyHours, Integer monthlyHours,
+                              Integer yearlyHours, Duration timeBetweenShifts, Duration periodLength) {
+            this.constraint = constraint;
+            this.dailyHours = dailyHours;
+            this.weeklyHours = weeklyHours;
+            this.monthlyHours = monthlyHours;
+            this.yearlyHours = yearlyHours;
+            this.timeBetweenShifts = timeBetweenShifts;
+            this.periodLength = periodLength;
+        }
+
+        public Constraints getConstraint() {
+            return constraint;
+        }
+
+        public Contract getContract(AtomicLong idGenerator) {
+            Contract out = new Contract(TENANT_ID, "Contract", dailyHours, weeklyHours, monthlyHours,
+                                        yearlyHours);
+            out.setId(idGenerator.getAndIncrement());
+            return out;
+        }
+
+        public List<Shift> generateShifts(ShiftBuilder shiftBuilder) {
+            List<Shift> out = new ArrayList<>();
+            shiftBuilder.withTimeBetweenShifts(timeBetweenShifts);
+            out.addAll(shiftBuilder.generateShifts(3));
+            shiftBuilder.startingAtDate(shiftBuilder.firstShiftStartTime.plus(periodLength));
+            out.addAll(shiftBuilder.generateShifts(3));
+            return out;
+        }
+    }
+
+    private static class ShiftBuilder {
+
+        OffsetDateTime firstShiftStartTime;
+        Duration lengthOfShift;
+        Duration durationBetweenShifts;
+        Spot shiftSpot;
+        AtomicLong idGenerator;
+
+        public ShiftBuilder(AtomicLong idGenerator) {
+            this.idGenerator = idGenerator;
+        }
+
+        public ShiftBuilder startingAtDate(OffsetDateTime startDate) {
+            this.firstShiftStartTime = startDate;
+            return this;
+        }
+
+        public ShiftBuilder withShiftLength(Duration duration) {
+            this.lengthOfShift = duration;
+            return this;
+        }
+
+        public ShiftBuilder withTimeBetweenShifts(Duration duration) {
+            this.durationBetweenShifts = duration;
+            return this;
+        }
+
+        public ShiftBuilder forSpot(Spot spot) {
+            this.shiftSpot = spot;
+            return this;
+        }
+
+        public List<Shift> generateShifts(int numberOfShifts) {
+            if (firstShiftStartTime == null || lengthOfShift == null || durationBetweenShifts == null ||
+                    shiftSpot == null) {
+                throw new IllegalStateException("ShiftBuilder not initialized");
+            }
+            List<Shift> out = new ArrayList<>();
+            OffsetDateTime shiftStart = firstShiftStartTime;
+
+            for (int i = 0; i < numberOfShifts; i++, shiftStart = shiftStart.plus(durationBetweenShifts)) {
+                out.add(new Shift(TENANT_ID, shiftSpot, shiftStart, shiftStart.plus(lengthOfShift)));
+                out.get(i).setId(idGenerator.getAndIncrement());
+            }
+
+            return out;
+        }
+    }
+}

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotRestControllerTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotRestControllerTest.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -65,8 +64,8 @@ public class SpotRestControllerTest extends AbstractEntityRequireTenantRestServi
         return restTemplate.postForEntity(spotPathURI + "add", spotView, Spot.class, tenantId);
     }
 
-    private ResponseEntity<Spot> updateSpot(Integer tenantId, HttpEntity<SpotView> request) {
-        return restTemplate.exchange(spotPathURI + "update", HttpMethod.PUT, request, Spot.class, tenantId);
+    private ResponseEntity<Spot> updateSpot(Integer tenantId, SpotView spotView) {
+        return restTemplate.postForEntity(spotPathURI + "update", spotView, Spot.class, tenantId);
     }
 
     @Before
@@ -91,8 +90,7 @@ public class SpotRestControllerTest extends AbstractEntityRequireTenantRestServi
 
         SpotView updatedSpot = new SpotView(TENANT_ID, "updatedSpot", Collections.emptySet());
         updatedSpot.setId(postResponse.getBody().getId());
-        HttpEntity<SpotView> request = new HttpEntity<>(updatedSpot);
-        ResponseEntity<Spot> putResponse = updateSpot(TENANT_ID, request);
+        ResponseEntity<Spot> putResponse = updateSpot(TENANT_ID, updatedSpot);
         assertThat(putResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         response = getSpot(TENANT_ID, putResponse.getBody().getId());

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotServiceTest.java
@@ -254,7 +254,7 @@ public class SpotServiceTest extends AbstractEntityRequireTenantRestServiceTest 
         String body = (new ObjectMapper()).writeValueAsString(updatedSpot);
 
         mvc.perform(MockMvcRequestBuilders
-                .put("/rest/tenant/{tenantId}/spot/update", TENANT_ID)
+                .post("/rest/tenant/{tenantId}/spot/update", TENANT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body)
                 .accept(MediaType.APPLICATION_JSON))
@@ -282,7 +282,7 @@ public class SpotServiceTest extends AbstractEntityRequireTenantRestServiceTest 
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/spot/update", 0)
+                        .post("/rest/tenant/{tenantId}/spot/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: " +
@@ -298,7 +298,7 @@ public class SpotServiceTest extends AbstractEntityRequireTenantRestServiceTest 
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/spot/update", TENANT_ID)
+                        .post("/rest/tenant/{tenantId}/spot/update", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
@@ -323,7 +323,7 @@ public class SpotServiceTest extends AbstractEntityRequireTenantRestServiceTest 
 
         assertThatExceptionOfType(NestedServletException.class)
                 .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/spot/update", 0)
+                        .post("/rest/tenant/{tenantId}/spot/update", 0)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body)))
                 .withMessage("Request processing failed; nested exception is java.lang.IllegalState" +


### PR DESCRIPTION
**WannabeSolverManager**
- Move `WannabeSolverManager` to Spring Boot
- Implement `solve()`, `terminate()`, `getRoster()`, and `getScoreDirector()` methods
- Add solver tests

**IndictmentUtils**
- Move `IndictmentUtils` to Spring Boot

**ShiftService**
- Implement `Shift` CRUD methods in `ShiftController.java` and `ShiftService.java`
- Add `ShiftRepository.java` for database persistence
- Add unit and integration tests for `Shift` CRUD methods

**ShiftRosterView**
- Implement `ShiftRosterView` GET methods in `RosterController.java` and `RosterService.java`
- Add integration tests for `ShiftRosterView` GET methods

**AvailabilityRosterView**
- Implement `AvailabilityRosterView` GET methods in `RosterController.java` and `RosterService.java`
- Add integration tests for `AvailabilityRosterView` GET methods

**Publish and Provision**
- Implement `publishAndProvision()` in `RosterController.java` and `RosterService.java`
- Add integration test for `publishAndProvision()`

**AdminService**
- Implement `resetApplication()` in `AdminController.java` and `AdminService.java`
- Add integration test for reset

**Minor Fixes**
- Add `Pagination` class to display entities in blocks
- Fix URL paths for certain `update` methods for consistency with old backend
- Add `OptaPlannerJacksonModule` to serialize score
- Reformat `Optional` object checks