### PR TITLE
Made RestServiceClient check for a string that beings with application/json instead of exact match

### DIFF
--- a/employee-rostering-frontend/src/store/rest/RestServiceClient.ts
+++ b/employee-rostering-frontend/src/store/rest/RestServiceClient.ts
@@ -21,6 +21,7 @@ import { ServerSideExceptionInfo, BasicObject } from 'types';
 import { ThunkDispatch } from 'redux-thunk';
 import { AppState } from 'store/types';
 
+const typeJsonRegex = new RegExp('application/json.*');
 export default class RestServiceClient {
 
   restClient: AxiosInstance;
@@ -61,7 +62,7 @@ export default class RestServiceClient {
       return Promise.resolve(res.data);
     }
     else if (this.dispatch !== null) {
-      if (res.headers["content-type"] === "application/json") {
+      if (typeJsonRegex.test(res.headers["content-type"])) {
         this.dispatch(alert.showServerError(res.data as unknown as ServerSideExceptionInfo & BasicObject))
       }
       else {


### PR DESCRIPTION
Exact match breaks when charset is specified; this does not.