### PR TITLE
PLANNER-1589: Add API Swagger Docs, add exception handling and change parent

### DIFF
--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -115,6 +115,10 @@
 
     <dependency>
       <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-benchmark</artifactId>
       <exclusions>
         <exclusion>

--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -54,7 +54,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <version.org.springframework>5.1.9.RELEASE</version.org.springframework>
-    <version.org.jacoco>0.8.4</version.org.jacoco>
   </properties>
 
   <dependencyManagement>
@@ -85,6 +84,11 @@
         <groupId>io.springfox</groupId>
         <artifactId>springfox-swagger-ui</artifactId>
         <version>2.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.agent</artifactId>
+        <version>0.8.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -350,6 +354,49 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jacoco</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.jacoco</groupId>
+          <artifactId>org.jacoco.agent</artifactId>
+          <classifier>runtime</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <systemPropertyVariables>
+                  <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                </systemPropertyVariables>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven2-plugin</artifactId>
+            <configuration>
+              <configuration>
+                <properties>
+                  <cargo.start.jvmargs>${jacoco.agent.line}</cargo.start.jvmargs>
+                </properties>
+              </configuration>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -76,6 +76,16 @@
         <artifactId>validation-api</artifactId>
         <version>2.0.1.Final</version>
       </dependency>
+      <dependency>
+        <groupId>io.springfox</groupId>
+        <artifactId>springfox-swagger2</artifactId>
+        <version>2.9.2</version>
+      </dependency>
+      <dependency>
+        <groupId>io.springfox</groupId>
+        <artifactId>springfox-swagger-ui</artifactId>
+        <version>2.9.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -125,6 +135,14 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger-ui</artifactId>
     </dependency>
 
     <!-- Testing dependencies -->

--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -385,10 +385,6 @@
         </pluginManagement>
         <plugins>
           <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
             <groupId>org.codehaus.cargo</groupId>
             <artifactId>cargo-maven2-plugin</artifactId>
             <configuration>

--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,15 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.6.RELEASE</version>
-    <relativePath/> <!-- lookup parent from repository -->
+    <groupId>org.optaweb.employeerostering</groupId>
+    <artifactId>employee-rostering</artifactId>
+    <version>7.28.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.optaweb.employeerostering</groupId>
   <artifactId>optaweb-employee-rostering-backend</artifactId>
-  <version>7.25.0-SNAPSHOT</version>
+  <version>7.28.0-SNAPSHOT</version>
   <name>optaweb-employee-rostering-backend</name>
   <description>Employee Rostering as a Service Spring Boot Backend</description>
 
@@ -54,17 +53,28 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-    <version.org.jacoco>0.8.3</version.org.jacoco>
+    <version.org.springframework>5.1.9.RELEASE</version.org.springframework>
+    <version.org.jacoco>0.8.4</version.org.jacoco>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-bom</artifactId>
-        <version>7.23.0.Final</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>2.1.8.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-dep</artifactId>
+        <version>1.9.12</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>2.0.1.Final</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -95,10 +105,6 @@
 
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-benchmark</artifactId>
       <exclusions>
         <exclusion>
@@ -112,11 +118,26 @@
       <artifactId>optaplanner-persistence-jackson</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-dep</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+
     <!-- Testing dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
@@ -128,6 +149,15 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <configuration>
+            <profiles>
+              <profile>local</profile>
+            </profiles>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
@@ -144,7 +174,7 @@
         <plugin>
           <groupId>org.pitest</groupId>
           <artifactId>pitest-maven</artifactId>
-          <version>1.4.3</version>
+          <version>1.4.10</version>
           <configuration>
             <reportsDirectory>local/pit-reports</reportsDirectory>
             <timestampedReports>true</timestampedReports>
@@ -208,7 +238,7 @@
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.6.0.1398</version>
+          <version>3.6.2</version>
           <executions>
             <execution>
               <phase>verify</phase>
@@ -224,7 +254,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -278,15 +308,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <profiles>
-            <profile>local</profile>
-          </profiles>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -307,50 +328,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jacoco</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.agent</artifactId>
-          <version>${version.org.jacoco}</version>
-          <classifier>runtime</classifier>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <systemPropertyVariables>
-                  <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
-                </systemPropertyVariables>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven2-plugin</artifactId>
-            <configuration>
-              <configuration>
-                <properties>
-                  <cargo.start.jvmargs>${jacoco.agent.line}</cargo.start.jvmargs>
-                </properties>
-              </configuration>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -54,6 +54,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <version.org.springframework>5.1.9.RELEASE</version.org.springframework>
+    <version.org.jacoco>0.8.4</version.org.jacoco>
   </properties>
 
   <dependencyManagement>
@@ -88,7 +89,7 @@
       <dependency>
         <groupId>org.jacoco</groupId>
         <artifactId>org.jacoco.agent</artifactId>
-        <version>0.8.4</version>
+        <version>${version.org.jacoco}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/ExceptionDataMapper.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/ExceptionDataMapper.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.optaweb.employeerostering.domain.exception.ServerSideExceptionInfo;
+import org.optaweb.employeerostering.util.HierarchyTree;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExceptionDataMapper {
+
+    private HierarchyTree<Class<? extends Throwable>, ExceptionData> exceptionHierarchyTree;
+
+    public ExceptionDataMapper() {
+        exceptionHierarchyTree = new HierarchyTree<>((a, b) -> {
+            if (a.equals(b)) {
+                return HierarchyTree.HierarchyRelationship.IS_THE_SAME_AS;
+            } else if (a.isAssignableFrom(b)) {
+                return HierarchyTree.HierarchyRelationship.IS_ABOVE;
+            } else if (b.isAssignableFrom(a)) {
+                return HierarchyTree.HierarchyRelationship.IS_BELOW;
+            } else {
+                return HierarchyTree.HierarchyRelationship.HAS_NO_DIRECT_RELATION;
+            }
+        });
+
+        for (ExceptionData exceptionData : ExceptionData.values()) {
+            exceptionHierarchyTree.putInHierarchy(exceptionData.getExceptionClass(), exceptionData);
+        }
+    }
+
+    public ExceptionData getExceptionDataForExceptionClass(Class<? extends Throwable> clazz) {
+        Optional<ExceptionData> exceptionData = exceptionHierarchyTree.getHierarchyClassValue(clazz);
+        if (exceptionData.isPresent()) {
+            return exceptionData.get();
+        } else {
+            throw new IllegalStateException("No ExceptionData for exception class (" + clazz + ").");
+        }
+    }
+
+    public enum ExceptionData {
+        GENERIC_EXCEPTION("ServerSideException.generic", HttpStatus.INTERNAL_SERVER_ERROR, Throwable.class,
+                          t -> Collections.emptyList()),
+        ILLEGAL_ARGUMENT("ServerSideException.illegalArgument", HttpStatus.INTERNAL_SERVER_ERROR,
+                         IllegalArgumentException.class,
+                         t -> Collections.singletonList(t.getMessage())),
+        NULL_POINTER("ServerSideException.nullPointer", HttpStatus.INTERNAL_SERVER_ERROR,
+                     NullPointerException.class, t -> Collections.emptyList()),
+        ENTITY_NOT_FOUND("ServerSideException.entityNotFound", HttpStatus.NOT_FOUND,
+                         EntityNotFoundException.class,
+                         t -> Collections.singletonList(t.getMessage())),
+        TRANSACTION_ROLLBACK("ServerSideException.rollback", HttpStatus.CONFLICT, DataIntegrityViolationException.class,
+                             t -> Collections.emptyList());
+
+        private String i18nKey;
+        private HttpStatus statusCode;
+        private Class<? extends Throwable> exceptionClass;
+        private Function<Throwable, List<String>> parameterMapping;
+
+        ExceptionData(String i18nKey, HttpStatus statusCode, Class<? extends Throwable> exceptionClass,
+                      Function<Throwable, List<String>> parameterMapping) {
+            this.i18nKey = i18nKey;
+            this.statusCode = statusCode;
+            this.exceptionClass = exceptionClass;
+            this.parameterMapping = parameterMapping;
+        }
+
+        public Class<? extends Throwable> getExceptionClass() {
+            return exceptionClass;
+        }
+
+        public HttpStatus getStatusCode() {
+            return statusCode;
+        }
+
+        public String getI18nKey() {
+            return i18nKey;
+        }
+
+        public ServerSideExceptionInfo getServerSideExceptionInfoFromException(Throwable exception) {
+            return new ServerSideExceptionInfo(exception, i18nKey,
+                                               parameterMapping.apply(exception).toArray(new String[0]));
+        }
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
@@ -21,8 +21,10 @@ import org.optaplanner.persistence.jackson.api.OptaPlannerJacksonModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
+@EnableSwagger2
 public class OptaWebEmployeeRosteringApplication {
 
     @Bean

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebEmployeeRosteringApplication.java
@@ -21,10 +21,8 @@ import org.optaplanner.persistence.jackson.api.OptaPlannerJacksonModule;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
-@EnableSwagger2
 public class OptaWebEmployeeRosteringApplication {
 
     @Bean

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebExceptionHandler.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebExceptionHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering;
+
+import org.optaweb.employeerostering.domain.exception.ServerSideExceptionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class OptaWebExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(OptaWebExceptionHandler.class);
+
+    private ExceptionDataMapper exceptionDataMapper;
+
+    public OptaWebExceptionHandler(ExceptionDataMapper exceptionDataMapper) {
+        this.exceptionDataMapper = exceptionDataMapper;
+    }
+
+    @ExceptionHandler(value = {Exception.class, RuntimeException.class})
+    protected ResponseEntity<ServerSideExceptionInfo> handleException(Throwable t, WebRequest request) {
+        final ExceptionDataMapper.ExceptionData exceptionData =
+                exceptionDataMapper.getExceptionDataForExceptionClass(t.getClass());
+        return new ResponseEntity<>(exceptionData.getServerSideExceptionInfoFromException(t),
+                                    exceptionData.getStatusCode());
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebExceptionHandler.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/OptaWebExceptionHandler.java
@@ -17,8 +17,6 @@
 package org.optaweb.employeerostering;
 
 import org.optaweb.employeerostering.domain.exception.ServerSideExceptionInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,8 +25,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @ControllerAdvice
 public class OptaWebExceptionHandler extends ResponseEntityExceptionHandler {
-
-    private static final Logger logger = LoggerFactory.getLogger(OptaWebExceptionHandler.class);
 
     private ExceptionDataMapper exceptionDataMapper;
 

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/SwaggerConfig.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/SwaggerConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger.web.DocExpansion;
+import springfox.documentation.swagger.web.UiConfiguration;
+import springfox.documentation.swagger.web.UiConfigurationBuilder;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("org.optaweb.employeerostering"))
+                .build();
+    }
+
+    @Bean
+    public UiConfiguration uiConfiguration() {
+        return UiConfigurationBuilder.builder()
+                .docExpansion(DocExpansion.LIST)
+                .build();
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/exception/ServerSideExceptionInfo.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/exception/ServerSideExceptionInfo.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.domain.exception;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ServerSideExceptionInfo {
+
+    private String i18nKey;
+    private String exceptionMessage;
+    private List<String> messageParameters;
+    private String exceptionClass;
+    private List<String> stackTrace;
+    private ServerSideExceptionInfo exceptionCause;
+
+    @SuppressWarnings("unused")
+    public ServerSideExceptionInfo() {
+
+    }
+
+    public ServerSideExceptionInfo(Throwable exception, String i18nKey, String... messageParameters) {
+        this.i18nKey = i18nKey;
+        this.exceptionMessage = exception.getMessage();
+        this.exceptionClass = exception.getClass().getName();
+        this.stackTrace = Arrays.stream(exception.getStackTrace())
+                .map(StackTraceElement::toString).collect(Collectors.toList());
+        this.messageParameters = Arrays.asList(messageParameters);
+        if (exception.getCause() != null) {
+            this.exceptionCause = new ServerSideExceptionInfo(exception.getCause(), "");
+        } else {
+            this.exceptionCause = null;
+        }
+    }
+
+    public String getI18nKey() {
+        return i18nKey;
+    }
+
+    public void setI18nKey(String i18nKey) {
+        this.i18nKey = i18nKey;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public List<String> getMessageParameters() {
+        return messageParameters;
+    }
+
+    public void setMessageParameters(List<String> messageParameters) {
+        this.messageParameters = messageParameters;
+    }
+
+    public String getExceptionClass() {
+        return exceptionClass;
+    }
+
+    public void setExceptionClass(String exceptionClass) {
+        this.exceptionClass = exceptionClass;
+    }
+
+    public List<String> getStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(List<String> stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+
+    public ServerSideExceptionInfo getExceptionCause() {
+        return exceptionCause;
+    }
+
+    public void setExceptionCause(ServerSideExceptionInfo exceptionCause) {
+        this.exceptionCause = exceptionCause;
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
@@ -16,6 +16,7 @@
 
 package org.optaweb.employeerostering.service.admin;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/admin")
 @Validated
+@Api(tags = "Admin")
 public class AdminController {
 
     private final AdminService adminService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/admin/AdminController.java
@@ -16,6 +16,7 @@
 
 package org.optaweb.employeerostering.service.admin;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
@@ -36,6 +37,7 @@ public class AdminController {
         Assert.notNull(adminService, "adminService must not be null.");
     }
 
+    @ApiOperation("Reset the application")
     @PostMapping("/reset")
     public ResponseEntity<Void> resetApplication() {
         adminService.resetApplication();

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
 import org.springframework.http.HttpStatus;
@@ -47,29 +48,34 @@ public class ContractController {
         Assert.notNull(contractService, "contractService must not be null.");
     }
 
+    @ApiOperation("Get a list of all contracts")
     @GetMapping("/")
     public ResponseEntity<List<Contract>> getContractList(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(contractService.getContractList(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a contract by id")
     @GetMapping("/{id}")
     public ResponseEntity<Contract> getContract(@PathVariable @Min(0) Integer tenantId,
                                                 @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(contractService.getContract(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Delete a contract")
     @DeleteMapping("/{id}")
     public ResponseEntity<Boolean> deleteContract(@PathVariable @Min(0) Integer tenantId,
                                                   @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(contractService.deleteContract(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new contract")
     @PostMapping("/add")
     public ResponseEntity<Contract> createContract(@PathVariable @Min(0) Integer tenantId,
                                                    @RequestBody @Valid ContractView contractView) {
         return new ResponseEntity<>(contractService.createContract(tenantId, contractView), HttpStatus.OK);
     }
 
+    @ApiOperation("Update a contract")
     @PostMapping("/update")
     public ResponseEntity<Contract> updateContract(@PathVariable @Min(0) Integer tenantId,
                                                    @RequestBody @Valid ContractView contractView) {

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/contract")
 @Validated
+@Api(tags = "Contract")
 public class ContractController {
 
     private final ContractService contractService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/contract/ContractRepository.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -29,5 +30,5 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
     @Query("select c from Contract c " +
             "where c.tenantId = :tenantId " +
             "order by LOWER(c.name)")
-    List<Contract> findAllByTenantId(Integer tenantId);
+    List<Contract> findAllByTenantId(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeAvailabilityRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeAvailabilityRepository.java
@@ -25,6 +25,7 @@ import org.optaweb.employeerostering.domain.employee.EmployeeAvailability;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -34,11 +35,11 @@ public interface EmployeeAvailabilityRepository extends JpaRepository<EmployeeAv
             " left join fetch ea.employee e" +
             " where ea.tenantId = :tenantId" +
             " order by e.name, ea.startDateTime")
-    List<EmployeeAvailability> findAllByTenantId(Integer tenantId);
+    List<EmployeeAvailability> findAllByTenantId(@Param("tenantId") Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from EmployeeAvailability ea where ea.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 
     @Query("select distinct ea from EmployeeAvailability ea" +
             " left join fetch ea.employee e" +
@@ -47,6 +48,8 @@ public interface EmployeeAvailabilityRepository extends JpaRepository<EmployeeAv
             " and ea.endDateTime >= :startDateTime" +
             " and ea.startDateTime < :endDateTime" +
             " order by e.name, ea.startDateTime")
-    List<EmployeeAvailability> filterWithEmployee(Integer tenantId, Set<Employee> employeeSet,
-                                                  OffsetDateTime startDateTime, OffsetDateTime endDateTime);
+    List<EmployeeAvailability> filterWithEmployee(@Param("tenantId") Integer tenantId,
+                                                  @Param("employeeSet") Set<Employee> employeeSet,
+                                                  @Param("startDateTime") OffsetDateTime startDateTime,
+                                                  @Param("endDateTime") OffsetDateTime endDateTime);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.employee.view.EmployeeAvailabilityView;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/employee")
 @Validated
+@Api(tags = "Employee")
 public class EmployeeController {
 
     private final EmployeeService employeeService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.employee.view.EmployeeAvailabilityView;
 import org.optaweb.employeerostering.domain.employee.view.EmployeeView;
@@ -53,28 +54,33 @@ public class EmployeeController {
     // Employee
     // ************************************************************************
 
+    @ApiOperation("Get a list of all employees")
     @GetMapping("/")
     public ResponseEntity<List<Employee>> getEmployeeList(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(employeeService.getEmployeeList(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Get an employee by id")
     @GetMapping("/{id}")
     public ResponseEntity<Employee> getEmployee(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(employeeService.getEmployee(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Delete an employee")
     @DeleteMapping("/{id}")
     public ResponseEntity<Boolean> deleteEmployee(@PathVariable @Min(0) Integer tenantId,
                                                   @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(employeeService.deleteEmployee(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new employee")
     @PostMapping("/add")
     public ResponseEntity<Employee> createEmployee(@PathVariable @Min(0) Integer tenantId,
                                                    @RequestBody @Valid EmployeeView employeeView) {
         return new ResponseEntity<>(employeeService.createEmployee(tenantId, employeeView), HttpStatus.OK);
     }
 
+    @ApiOperation("Update an employee")
     @PostMapping("/update")
     public ResponseEntity<Employee> updateEmployee(@PathVariable @Min(0) Integer tenantId,
                                                    @RequestBody @Valid EmployeeView employeeView) {
@@ -85,28 +91,34 @@ public class EmployeeController {
     // EmployeeAvailability
     // ************************************************************************
 
+    @ApiOperation("Get an employee availability by id")
     @GetMapping("/availability/{id}")
     public ResponseEntity<EmployeeAvailabilityView> getEmployeeAvailability(@PathVariable @Min(0) Integer tenantId,
                                                                             @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(employeeService.getEmployeeAvailability(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new employee availability")
     @PostMapping("/availability/add")
     public ResponseEntity<EmployeeAvailabilityView> createEmployeeAvailability(@PathVariable @Min(0) Integer tenantId,
-                                                                            @RequestBody @Valid EmployeeAvailabilityView
-                                                                                    employeeAvailabilityView) {
+                                                                               @RequestBody @Valid
+                                                                                       EmployeeAvailabilityView
+                                                                                       employeeAvailabilityView) {
         return new ResponseEntity<>(employeeService.createEmployeeAvailability(tenantId, employeeAvailabilityView),
                                     HttpStatus.OK);
     }
 
+    @ApiOperation("Update an employee availability")
     @PutMapping("/availability/update")
     public ResponseEntity<EmployeeAvailabilityView> updateEmployeeAvailability(@PathVariable @Min(0) Integer tenantId,
-                                                                           @RequestBody @Valid EmployeeAvailabilityView
-                                                                                   employeeAvailabilityView) {
+                                                                               @RequestBody @Valid
+                                                                                       EmployeeAvailabilityView
+                                                                                       employeeAvailabilityView) {
         return new ResponseEntity<>(employeeService.updateEmployeeAvailability(tenantId, employeeAvailabilityView),
                                     HttpStatus.OK);
     }
 
+    @ApiOperation("Delete an employee availability")
     @DeleteMapping("/availability/{id}")
     public ResponseEntity<Boolean> deleteEmployeeAvailability(@PathVariable @Min(0) Integer tenantId,
                                                               @PathVariable @Min(0) Long id) {

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/employee/EmployeeRepository.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -31,9 +32,9 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     @Query("select e from Employee e " +
             "where e.tenantId = :tenantId " +
             "order by LOWER(e.name)")
-    List<Employee> findAllByTenantId(Integer tenantId, Pageable pageable);
+    List<Employee> findAllByTenantId(@Param("tenantId") Integer tenantId, Pageable pageable);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Employee e where e.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.roster.PublishResult;
 import org.optaweb.employeerostering.domain.roster.RosterState;
@@ -55,6 +56,7 @@ public class RosterController {
     // RosterState
     // ************************************************************************
 
+    @ApiOperation("Get the current roster state")
     @GetMapping("/{id}")
     public ResponseEntity<RosterState> getRosterState(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(rosterService.getRosterState(tenantId), HttpStatus.OK);
@@ -64,6 +66,7 @@ public class RosterController {
     // ShiftRosterView
     // ************************************************************************
 
+    @ApiOperation("Get the current shift roster view")
     @GetMapping("/shiftRosterView/current")
     public ResponseEntity<ShiftRosterView> getCurrentShiftRosterView(@PathVariable @Min(0) Integer tenantId,
                                                                      @RequestParam(name = "p", required = false)
@@ -74,6 +77,7 @@ public class RosterController {
                                                                             numberOfItemsPerPage), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a shift roster view between two dates")
     @GetMapping("/shiftRosterView")
     public ResponseEntity<ShiftRosterView> getShiftRosterView(@PathVariable @Min(0) Integer tenantId,
                                                               @RequestParam(name = "p", required = false)
@@ -88,6 +92,7 @@ public class RosterController {
 
     // TODO: find out if there a way to pass lists in GET requests
     // TODO naming "for" is too abstract: we might add a sibling rest method that filters on another type than spots too
+    @ApiOperation("Get a shift roster view between two dates for a subset of the spots")
     @PostMapping("/shiftRosterView/for")
     public ResponseEntity<ShiftRosterView> getShiftRosterViewFor(@PathVariable @Min(0) Integer tenantId,
                                                                  @RequestParam(name = "startDate")
@@ -102,6 +107,7 @@ public class RosterController {
     // AvailabilityRosterView
     // ************************************************************************
 
+    @ApiOperation("Get the current availability roster view")
     @GetMapping("/availabilityRosterView/current")
     public ResponseEntity<AvailabilityRosterView> getCurrentAvailabilityRosterView(
             @PathVariable @Min(0) Integer tenantId, @RequestParam(name = "p", required = false) Integer pageNumber,
@@ -111,6 +117,7 @@ public class RosterController {
                                     HttpStatus.OK);
     }
 
+    @ApiOperation("Get an availability roster view between two dates")
     @GetMapping("/availabilityRosterView")
     public ResponseEntity<AvailabilityRosterView> getAvailabilityRosterView(
             @PathVariable @Min(0) Integer tenantId, @RequestParam(name = "p", required = false) Integer pageNumber,
@@ -122,6 +129,7 @@ public class RosterController {
                                     HttpStatus.OK);
     }
 
+    @ApiOperation("Get an availability roster view between two dates for a subset of the employees")
     @PostMapping("/availabilityRosterView/for")
     // TODO naming "for" is too abstract: we might add a sibling rest method that filters on another type than spots too
     public ResponseEntity<AvailabilityRosterView> getAvailabilityRosterViewFor(
@@ -136,11 +144,13 @@ public class RosterController {
     // Solver
     // ************************************************************************
 
+    @ApiOperation("Start solving the roster. This will assign each shift to an employee")
     @PostMapping("/solve")
     public void solveRoster(@PathVariable @Min(0) Integer tenantId) {
         rosterService.solveRoster(tenantId);
     }
 
+    @ApiOperation("Stop solving the roster, if it hasn't terminated automatically already")
     @PostMapping("/terminate")
     public void terminateRosterEarly(@PathVariable @Min(0) Integer tenantId) {
         rosterService.terminateRosterEarly(tenantId);
@@ -150,6 +160,7 @@ public class RosterController {
     // Publish
     // ************************************************************************
 
+    @ApiOperation("Publish the next set of draft shifts and create a new draft shift from the rotation template")
     @PostMapping("/publishAndProvision")
     public ResponseEntity<PublishResult> publishAndProvision(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(rosterService.publishAndProvision(tenantId), HttpStatus.OK);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.roster.PublishResult;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/roster")
 @Validated
+@Api(tags = "Roster")
 public class RosterController {
 
     private final RosterService rosterService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterStateRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterStateRepository.java
@@ -22,6 +22,7 @@ import org.optaweb.employeerostering.domain.roster.RosterState;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -29,9 +30,9 @@ public interface RosterStateRepository extends JpaRepository<RosterState, Long> 
 
     @Query("select distinct rs from RosterState rs " +
             "where rs.tenantId = :tenantId")
-    Optional<RosterState> findByTenantId(Integer tenantId);
+    Optional<RosterState> findByTenantId(@Param("tenantId") Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from RosterState rs where rs.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/rotation/RotationController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/rotation/RotationController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.rotation.view.ShiftTemplateView;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,32 +48,39 @@ public class RotationController {
         Assert.notNull(rotationService, "rotationService must not be null.");
     }
 
+    @ApiOperation("Get a list of all shift templates")
     @GetMapping("/")
     public ResponseEntity<List<ShiftTemplateView>> getShiftTemplateList(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(rotationService.getShiftTemplateList(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a shift template by id")
     @GetMapping("/{id}")
     public ResponseEntity<ShiftTemplateView> getShiftTemplate(@PathVariable @Min(0) Integer tenantId,
                                                               @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(rotationService.getShiftTemplate(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Delete a shift template")
     @DeleteMapping("/{id}")
     public ResponseEntity<Boolean> deleteShiftTemplate(@PathVariable @Min(0) Integer tenantId,
                                                        @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(rotationService.deleteShiftTemplate(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new shift template")
     @PostMapping("/add")
     public ResponseEntity<ShiftTemplateView> createShiftTemplate(@PathVariable @Min(0) Integer tenantId,
-                                                              @RequestBody @Valid ShiftTemplateView shiftTemplateView) {
+                                                                 @RequestBody @Valid
+                                                                         ShiftTemplateView shiftTemplateView) {
         return new ResponseEntity<>(rotationService.createShiftTemplate(tenantId, shiftTemplateView), HttpStatus.OK);
     }
 
+    @ApiOperation("Update a shift template")
     @PutMapping("/update")
     public ResponseEntity<ShiftTemplateView> updateShiftTemplate(@PathVariable @Min(0) Integer tenantId,
-                                                              @RequestBody @Valid ShiftTemplateView shiftTemplateView) {
+                                                                 @RequestBody @Valid
+                                                                         ShiftTemplateView shiftTemplateView) {
         return new ResponseEntity<>(rotationService.updateShiftTemplate(tenantId, shiftTemplateView), HttpStatus.OK);
     }
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/rotation/RotationController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/rotation/RotationController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.rotation.view.ShiftTemplateView;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/rotation")
 @Validated
+@Api(tags = "Rotation")
 public class RotationController {
 
     private final RotationService rotationService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/rotation/ShiftTemplateRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/rotation/ShiftTemplateRepository.java
@@ -22,6 +22,7 @@ import org.optaweb.employeerostering.domain.rotation.ShiftTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -32,9 +33,9 @@ public interface ShiftTemplateRepository extends JpaRepository<ShiftTemplate, Lo
             "left join fetch sa.rotationEmployee re " +
             "where sa.tenantId = :tenantId " +
             "order by sa.startDayOffset, sa.startTime, s.name, re.name")
-    List<ShiftTemplate> findAllByTenantId(Integer tenantId);
+    List<ShiftTemplate> findAllByTenantId(@Param("tenantId") Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from ShiftTemplate st where st.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.shift.view.ShiftView;
 
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/shift")
 @Validated
+@Api(tags = "Shift")
 public class ShiftController {
 
     private final ShiftService shiftService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.shift.view.ShiftView;
 
 import org.springframework.http.HttpStatus;
@@ -48,38 +49,32 @@ public class ShiftController {
         Assert.notNull(shiftService, "shiftService must not be null.");
     }
 
+    @ApiOperation("Get a list of all shifts")
     @GetMapping("/")
     public ResponseEntity<List<ShiftView>> getShiftList(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(shiftService.getShiftList(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a shift by id")
     @GetMapping("/{id}")
     public ResponseEntity<ShiftView> getShift(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(shiftService.getShift(tenantId, id), HttpStatus.OK);
     }
 
-    /**
-     * @param id never null
-     * @return return true if the shift was removed, false otherwise
-     */
+    @ApiOperation("Delete a shift")
     @DeleteMapping("/{id}")
     public ResponseEntity<Boolean> deleteShift(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(shiftService.deleteShift(tenantId, id), HttpStatus.OK);
     }
 
-    /**
-     * @param shiftView never null
-     * @return never null, the id
-     */
+    @ApiOperation("Add a new shift")
     @PostMapping("/add")
     public ResponseEntity<ShiftView> createShift(@PathVariable @Min(0) Integer tenantId,
                                                  @RequestBody @Valid ShiftView shiftView) {
         return new ResponseEntity<>(shiftService.createShift(tenantId, shiftView), HttpStatus.OK);
     }
 
-    /**
-     * @param shiftView never null
-     */
+    @ApiOperation("Update a shift")
     @PutMapping("/update")
     public ResponseEntity<ShiftView> updateShift(@PathVariable @Min(0) Integer tenantId,
                                                  @RequestBody @Valid ShiftView shiftView) {

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/shift/ShiftRepository.java
@@ -26,6 +26,7 @@ import org.optaweb.employeerostering.domain.spot.Spot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -37,12 +38,12 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             " left join fetch sa.employee e" +
             " where sa.tenantId = :tenantId" +
             " order by sa.startDateTime, s.name, e.name")
-    List<Shift> findAllByTenantId(Integer tenantId);
+    List<Shift> findAllByTenantId(@Param("tenantId") Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Shift s" +
             " where s.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 
     @Query("select distinct sa from Shift sa" +
             " left join fetch sa.spot s" +
@@ -53,8 +54,9 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             " and sa.endDateTime >= :startDateTime" +
             " and sa.startDateTime < :endDateTime" +
             " order by sa.startDateTime, s.name, e.name")
-    List<Shift> filterWithSpots(Integer tenantId, Set<Spot> spotSet, OffsetDateTime startDateTime,
-                                OffsetDateTime endDateTime);
+    List<Shift> filterWithSpots(@Param("tenantId") Integer tenantId, @Param("spotSet") Set<Spot> spotSet,
+                                @Param("startDateTime") OffsetDateTime startDateTime,
+                                @Param("endDateTime") OffsetDateTime endDateTime);
 
     @Query("select distinct sa from Shift sa" +
             " left join fetch sa.spot s" +
@@ -65,6 +67,8 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             " and sa.endDateTime >= :startDateTime" +
             " and sa.startDateTime < :endDateTime" +
             " order by sa.startDateTime, s.name, e.name")
-    List<Shift> filterWithEmployees(Integer tenantId, Set<Employee> employeeSet, OffsetDateTime startDateTime,
-                                    OffsetDateTime endDateTime);
+    List<Shift> filterWithEmployees(@Param("tenantId") Integer tenantId,
+                                    @Param("employeeSet") Set<Employee> employeeSet,
+                                    @Param("startDateTime") OffsetDateTime startDateTime,
+                                    @Param("endDateTime") OffsetDateTime endDateTime);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.skill.view.SkillView;
 import org.springframework.http.HttpStatus;
@@ -47,27 +48,32 @@ public class SkillController {
         Assert.notNull(skillService, "skillService must not be null.");
     }
 
+    @ApiOperation("Get a list of all skills")
     @GetMapping("/")
     public ResponseEntity<List<Skill>> getSkillList(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(skillService.getSkillList(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a skill by id")
     @GetMapping("/{id}")
     public ResponseEntity<Skill> getSkill(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(skillService.getSkill(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Delete a skill")
     @DeleteMapping("/{id}")
     public ResponseEntity<Boolean> deleteSkill(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(skillService.deleteSkill(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new skill")
     @PostMapping("/add")
     public ResponseEntity<Skill> createSkill(@PathVariable @Min(0) Integer tenantId,
                                              @RequestBody @Valid SkillView skillView) {
         return new ResponseEntity<>(skillService.createSkill(tenantId, skillView), HttpStatus.OK);
     }
 
+    @ApiOperation("Update a skill")
     @PostMapping("/update")
     public ResponseEntity<Skill> updateSkill(@PathVariable @Min(0) Integer tenantId,
                                              @RequestBody @Valid SkillView skillView) {

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.skill.view.SkillView;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/skill")
 @Validated
+@Api(tags = "Skill")
 public class SkillController {
 
     private final SkillService skillService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/skill/SkillRepository.java
@@ -22,6 +22,7 @@ import org.optaweb.employeerostering.domain.skill.Skill;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -30,9 +31,9 @@ public interface SkillRepository extends JpaRepository<Skill, Long> {
     @Query("select s from Skill s " +
             "where s.tenantId = :tenantId " +
             "order by LOWER(s.name)")
-    List<Skill> findAllByTenantId(Integer tenantId);
+    List<Skill> findAllByTenantId(@Param("tenantId") Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Skill s where s.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.domain.spot.view.SpotView;
 import org.springframework.http.HttpStatus;
@@ -47,27 +48,32 @@ public class SpotController {
         Assert.notNull(spotService, "spotService must not be null.");
     }
 
+    @ApiOperation("Get a list of all spots")
     @GetMapping("/")
     public ResponseEntity<List<Spot>> getSpotList(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(spotService.getSpotList(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a spot by id")
     @GetMapping("/{id}")
     public ResponseEntity<Spot> getSpot(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(spotService.getSpot(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Delete a spot")
     @DeleteMapping("/{id}")
     public ResponseEntity<Boolean> deleteSpot(@PathVariable @Min(0) Integer tenantId, @PathVariable @Min(0) Long id) {
         return new ResponseEntity<>(spotService.deleteSpot(tenantId, id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new spot")
     @PostMapping("/add")
     public ResponseEntity<Spot> createSpot(@PathVariable @Min(0) Integer tenantId,
                                            @RequestBody @Valid SpotView spotView) {
         return new ResponseEntity<>(spotService.createSpot(tenantId, spotView), HttpStatus.OK);
     }
 
+    @ApiOperation("Update a spot")
     @PostMapping("/update")
     public ResponseEntity<Spot> updateSpot(@PathVariable @Min(0) Integer tenantId,
                                            @RequestBody @Valid SpotView spotView) {

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotController.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.domain.spot.view.SpotView;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant/{tenantId}/spot")
 @Validated
+@Api(tags = "Spot")
 public class SpotController {
 
     private final SpotService spotService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/spot/SpotRepository.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -31,9 +32,9 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
     @Query("select s from Spot s " +
             "where s.tenantId = :tenantId " +
             "order by LOWER(s.name)")
-    List<Spot> findAllByTenantId(Integer tenantId, Pageable pageable);
+    List<Spot> findAllByTenantId(@Param("tenantId") Integer tenantId, Pageable pageable);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from Spot s where s.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/RosterParametrizationRepository.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/RosterParametrizationRepository.java
@@ -22,6 +22,7 @@ import org.optaweb.employeerostering.domain.tenant.RosterParametrization;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -29,9 +30,9 @@ public interface RosterParametrizationRepository extends JpaRepository<RosterPar
 
     @Query("select distinct rp from RosterParametrization rp " +
             "where rp.tenantId = :tenantId")
-    Optional<RosterParametrization> findByTenantId(Integer tenantId);
+    Optional<RosterParametrization> findByTenantId(@Param("tenantId") Integer tenantId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from RosterParametrization rp where rp.tenantId = :tenantId")
-    void deleteForTenant(Integer tenantId);
+    void deleteForTenant(@Param("tenantId") Integer tenantId);
 }

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/TenantController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/TenantController.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.roster.view.RosterStateView;
 import org.optaweb.employeerostering.domain.tenant.RosterParametrization;
 import org.optaweb.employeerostering.domain.tenant.Tenant;
@@ -51,21 +52,25 @@ public class TenantController {
     // Tenant
     // ************************************************************************
 
+    @ApiOperation("Get a list of all tenants")
     @GetMapping("/")
     public ResponseEntity<List<Tenant>> getTenantList() {
         return new ResponseEntity<>(tenantService.getTenantList(), HttpStatus.OK);
     }
 
+    @ApiOperation("Get a tenant by id")
     @GetMapping("/{id}")
     public ResponseEntity<Tenant> getTenant(@PathVariable @Min(0) Integer id) {
         return new ResponseEntity<>(tenantService.getTenant(id), HttpStatus.OK);
     }
 
+    @ApiOperation("Add a new tenant")
     @PostMapping("/add")
     public ResponseEntity<Tenant> createTenant(@RequestBody @Valid RosterStateView initialRosterStateView) {
         return new ResponseEntity<>(tenantService.createTenant(initialRosterStateView), HttpStatus.OK);
     }
 
+    @ApiOperation("Delete a tenant")
     @PostMapping("/remove/{id}")
     public ResponseEntity<Boolean> deleteTenant(@PathVariable @Min(0) Integer id) {
         return new ResponseEntity<>(tenantService.deleteTenant(id), HttpStatus.OK);
@@ -75,11 +80,13 @@ public class TenantController {
     // RosterParametrization
     // ************************************************************************
 
+    @ApiOperation("Get a tenant roster parametrization")
     @GetMapping("/{tenantId}/parametrization")
     public ResponseEntity<RosterParametrization> getRosterParametrization(@PathVariable @Min(0) Integer tenantId) {
         return new ResponseEntity<>(tenantService.getRosterParametrization(tenantId), HttpStatus.OK);
     }
 
+    @ApiOperation("Update a tenant roster parametrization")
     @PostMapping("/parametrization/update")
     public ResponseEntity<RosterParametrization> updateRosterParametrization(
             @RequestBody @Valid RosterParametrizationView rosterParametrizationView) {
@@ -88,6 +95,7 @@ public class TenantController {
     }
 
     // TODO: Where should this be?
+    @ApiOperation("Get supported timezones")
     @GetMapping("/supported/timezones")
     public ResponseEntity<List<ZoneId>> getSupportedTimezones() {
         return new ResponseEntity<>(tenantService.getSupportedTimezones(), HttpStatus.OK);

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/TenantController.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/tenant/TenantController.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.optaweb.employeerostering.domain.roster.view.RosterStateView;
 import org.optaweb.employeerostering.domain.tenant.RosterParametrization;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/tenant")
 @Validated
+@Api(tags = "Tenant")
 public class TenantController {
 
     private final TenantService tenantService;

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/util/HierarchyTree.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/util/HierarchyTree.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A data structure representing a hierarchy tree. Each node in the tree represent
+ * a subclass of the Hierarchy. Can be used to find the most specific class
+ * an object is applicable to (example: in a Hierarchy tree containing Throwable and RuntimeException,
+ * IllegalStateException should map to RuntimeException, not Throwable).
+ * @param <K> The type of the key element in the Hierarchy
+ * @param <V> The type of the value element in the Hierarchy
+ */
+public class HierarchyTree<K, V> {
+
+    private Collection<HierarchyNode> hierarchyDisjointClasses;
+    private HierarchyRelation<K> hierarchyRelation;
+
+    public HierarchyTree(HierarchyRelation<K> hierarchyRelation) {
+        this.hierarchyRelation = hierarchyRelation;
+        hierarchyDisjointClasses = new ArrayList<>();
+    }
+
+    /**
+     * Puts the hierarchy class into the Hierarchy tree.
+     * @param key The key of the hierarchy class, determines where it is put into the tree.
+     * @param value The value of the hierarchy class.
+     */
+    public void putInHierarchy(K key, V value) {
+        HierarchyNode newChild = new HierarchyNode(key, value);
+        Collection<HierarchyNode> subclassesOfNewChild = hierarchyDisjointClasses.stream()
+                .filter(c -> hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, c.classKey) ==
+                        HierarchyRelationship.IS_ABOVE)
+                .collect(Collectors.toList());
+        if (subclassesOfNewChild.isEmpty()) {
+            Optional<HierarchyNode> superclassOfNewChild = hierarchyDisjointClasses.stream()
+                    .filter(c -> hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, c.classKey) ==
+                            HierarchyRelationship.IS_BELOW)
+                    .findAny();
+            if (superclassOfNewChild.isPresent()) {
+                superclassOfNewChild.get().addChild(newChild);
+            } else {
+                hierarchyDisjointClasses.add(newChild);
+            }
+        } else {
+            hierarchyDisjointClasses.removeAll(subclassesOfNewChild);
+            subclassesOfNewChild.forEach(newChild::addChild);
+            hierarchyDisjointClasses.add(newChild);
+        }
+    }
+
+    /**
+     * Finds the most specific hierarchy class of key, and returns its value.
+     * If it belongs to multiple hierarchy branches (example: in the divisibility hierarchy tree
+     * with classes "2" and "3", "6" belongs to both "2" and "3"), it returns the value of the most specific
+     * hierarchy class of a random branch.
+     * @param key What to find the most specific hierarchy class of.
+     * @return The value of the most specific hierarchy class of key.
+     */
+    public Optional<V> getHierarchyClassValue(K key) {
+        List<HierarchyNode> superclassesOfItem = hierarchyDisjointClasses.stream()
+                .filter(c -> {
+                    HierarchyRelationship relationship = hierarchyRelation.getHierarchyRelationshipBetween(key,
+                                                                                                           c.classKey);
+                    return relationship == HierarchyRelationship.IS_BELOW || relationship ==
+                            HierarchyRelationship.IS_THE_SAME_AS;
+                })
+                .collect(Collectors.toList());
+
+        if (superclassesOfItem.isEmpty()) {
+            return Optional.empty();
+        } else {
+            HierarchyNode mostSpecificInstance = superclassesOfItem.get(0).findHierarchyClassOf(key);
+            for (HierarchyNode superclassOfItem : superclassesOfItem.subList(1, superclassesOfItem.size())) {
+                HierarchyNode mostSpecificInstanceInSuperclass = superclassOfItem.findHierarchyClassOf(key);
+                if (hierarchyRelation.getHierarchyRelationshipBetween(mostSpecificInstanceInSuperclass.classKey,
+                                                                      mostSpecificInstance.classKey)
+                        == HierarchyRelationship.IS_BELOW) {
+                    mostSpecificInstance = mostSpecificInstanceInSuperclass;
+                }
+            }
+            return Optional.of(mostSpecificInstance.classValue);
+        }
+    }
+
+    private class HierarchyNode {
+
+        private K classKey;
+        private V classValue;
+        private Collection<HierarchyNode> hierarchySubclasses;
+
+        public HierarchyNode(K classKey, V classValue) {
+            this.classKey = classKey;
+            this.classValue = classValue;
+            hierarchySubclasses = new ArrayList<>();
+        }
+
+        public void addChild(HierarchyNode newChild) {
+            if (hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, classKey) !=
+                    HierarchyRelationship.IS_BELOW) {
+                throw new IllegalArgumentException("The child you tried to add (" + newChild.classKey +
+                                                           ") is not a desendant of root (" + classKey + ").");
+            }
+            Collection<HierarchyNode> subclassesOfNewChild = hierarchySubclasses.stream()
+                    .filter(c -> hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, c.classKey) ==
+                            HierarchyRelationship.IS_ABOVE)
+                    .collect(Collectors.toList());
+            if (subclassesOfNewChild.isEmpty()) {
+                Optional<HierarchyNode> superclassOfNewChild = hierarchySubclasses.stream()
+                        .filter(c -> hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, c.classKey) ==
+                                HierarchyRelationship.IS_BELOW)
+                        .findAny();
+                if (superclassOfNewChild.isPresent()) {
+                    superclassOfNewChild.get().addChild(newChild);
+                } else {
+                    hierarchySubclasses.add(newChild);
+                }
+            } else {
+                hierarchySubclasses.removeAll(subclassesOfNewChild);
+                subclassesOfNewChild.forEach(newChild::addChild);
+                hierarchySubclasses.add(newChild);
+            }
+        }
+
+        public HierarchyNode findHierarchyClassOf(K key) {
+            HierarchyRelationship classRelationship = hierarchyRelation.getHierarchyRelationshipBetween(key, classKey);
+            if (!(classRelationship == HierarchyRelationship.IS_BELOW || classRelationship ==
+                    HierarchyRelationship.IS_THE_SAME_AS)) {
+                throw new IllegalArgumentException("The item (" + key + ") is not a desendant of root (" +
+                                                           classKey + ").");
+            }
+            List<HierarchyNode> superclassesOfItem = hierarchySubclasses.stream()
+                    .filter(c -> {
+                        HierarchyRelationship relationship = hierarchyRelation.getHierarchyRelationshipBetween(
+                                key, c.classKey);
+                        return relationship == HierarchyRelationship.IS_BELOW || relationship ==
+                                HierarchyRelationship.IS_THE_SAME_AS;
+                    })
+                    .collect(Collectors.toList());
+
+            if (superclassesOfItem.isEmpty()) {
+                return this;
+            } else {
+                HierarchyNode mostSpecificInstance = superclassesOfItem.get(0).findHierarchyClassOf(key);
+                for (HierarchyNode superclassOfItem : superclassesOfItem.subList(1, superclassesOfItem.size())) {
+                    HierarchyNode mostSpecificInstanceInSuperclass = superclassOfItem.findHierarchyClassOf(key);
+                    if (hierarchyRelation.getHierarchyRelationshipBetween(mostSpecificInstanceInSuperclass.classKey,
+                                                                          mostSpecificInstance.classKey)
+                            == HierarchyRelationship.IS_BELOW) {
+                        mostSpecificInstance = mostSpecificInstanceInSuperclass;
+                    }
+                }
+                return mostSpecificInstance;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return classKey.toString();
+        }
+    }
+
+    public enum HierarchyRelationship {
+        // Returned when the first object is a generalization of the second object
+        // (ex: Throwable IS_ABOVE RuntimeException)
+        IS_ABOVE,
+
+        // Returned when the first object is a specialization of the second object
+        // (ex: RuntimeException IS_BELOW Throwable)
+        IS_BELOW,
+
+        //Returned when the first object is identical to the second object
+        // (ex: Throwable IS_THE_SAME_AS Throwable)
+        IS_THE_SAME_AS,
+
+        // Returned when the first object and the second object have no direct relation
+        // (ex: RuntimeException HAS_NO_DIRECT_RELATION Exception)
+        // (typically, this means they have a common ancestor, but this is not always the case)
+        HAS_NO_DIRECT_RELATION
+    }
+
+    public interface HierarchyRelation<K> {
+
+        public HierarchyRelationship getHierarchyRelationshipBetween(K first, K second);
+    }
+}

--- a/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/util/HierarchyTree.java
+++ b/employee-rostering-backend/src/main/java/org/optaweb/employeerostering/util/HierarchyTree.java
@@ -118,7 +118,7 @@ public class HierarchyTree<K, V> {
             if (hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, classKey) !=
                     HierarchyRelationship.IS_BELOW) {
                 throw new IllegalArgumentException("The child you tried to add (" + newChild.classKey +
-                                                           ") is not a desendant of root (" + classKey + ").");
+                                                           ") is not a descendant of root (" + classKey + ").");
             }
             Collection<HierarchyNode> subclassesOfNewChild = hierarchySubclasses.stream()
                     .filter(c -> hierarchyRelation.getHierarchyRelationshipBetween(newChild.classKey, c.classKey) ==
@@ -145,7 +145,7 @@ public class HierarchyTree<K, V> {
             HierarchyRelationship classRelationship = hierarchyRelation.getHierarchyRelationshipBetween(key, classKey);
             if (!(classRelationship == HierarchyRelationship.IS_BELOW || classRelationship ==
                     HierarchyRelationship.IS_THE_SAME_AS)) {
-                throw new IllegalArgumentException("The item (" + key + ") is not a desendant of root (" +
+                throw new IllegalArgumentException("The item (" + key + ") is not a descendant of root (" +
                                                            classKey + ").");
             }
             List<HierarchyNode> superclassesOfItem = hierarchySubclasses.stream()

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/exception/ExceptionDataMapperTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/exception/ExceptionDataMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.exception;
+
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.RollbackException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.optaweb.employeerostering.ExceptionDataMapper;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class ExceptionDataMapperTest {
+
+    private ExceptionDataMapper tested;
+
+    @Test
+    public void testGetExceptionDataForExceptionClass() {
+        tested = new ExceptionDataMapper();
+        assertEquals(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION,
+                     tested.getExceptionDataForExceptionClass(Throwable.class));
+        assertEquals(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION,
+                     tested.getExceptionDataForExceptionClass(IllegalStateException.class));
+        assertEquals(ExceptionDataMapper.ExceptionData.ILLEGAL_ARGUMENT,
+                     tested.getExceptionDataForExceptionClass(IllegalArgumentException.class));
+        assertEquals(ExceptionDataMapper.ExceptionData.NULL_POINTER,
+                     tested.getExceptionDataForExceptionClass(NullPointerException.class));
+        assertEquals(ExceptionDataMapper.ExceptionData.ENTITY_NOT_FOUND,
+                     tested.getExceptionDataForExceptionClass(EntityNotFoundException.class));
+        assertEquals(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION,
+                     tested.getExceptionDataForExceptionClass(RollbackException.class));
+    }
+}

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
@@ -103,7 +103,7 @@ public class RosterGeneratorTest {
     
     @After
     public void cleanup() {
-        restTemplate.delete(tenantPathURI + "/remove/" + tenantId);
+        restTemplate.postForEntity(tenantPathURI + "remove/" + tenantId, null, Void.class);
     }
 
     @Test

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftServiceTest.java
@@ -47,9 +47,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.NestedServletException;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -104,8 +102,8 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
     @Test
     public void getShiftListTest() throws Exception {
         mvc.perform(MockMvcRequestBuilders
-                .get("/rest/tenant/{tenantId}/shift/", TENANT_ID)
-                .accept(MediaType.APPLICATION_JSON))
+                            .get("/rest/tenant/{tenantId}/shift/", TENANT_ID)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk());
     }
@@ -122,8 +120,8 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
         ShiftView persistedShift = shiftService.createShift(TENANT_ID, shiftView);
 
         mvc.perform(MockMvcRequestBuilders
-                .get("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, persistedShift.getId())
-                .accept(MediaType.APPLICATION_JSON))
+                            .get("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, persistedShift.getId())
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.rotationEmployeeId").value(
@@ -136,12 +134,17 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
     }
 
     @Test
-    public void getNonExistentShiftTest() {
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .get("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, 0)))
-                .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
-                        "Exception: No Shift entity found with ID (0).");
+    public void getNonExistentShiftTest() throws Exception {
+        String exceptionMessage = "No Shift entity found with ID (0).";
+        String exceptionClass = "javax.persistence.EntityNotFoundException";
+
+        mvc.perform(MockMvcRequestBuilders
+                            .get("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, 0)
+                            .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
@@ -156,8 +159,8 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
         ShiftView persistedShift = shiftService.createShift(TENANT_ID, shiftView);
 
         mvc.perform(MockMvcRequestBuilders
-                .delete("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, persistedShift.getId())
-                .accept(MediaType.APPLICATION_JSON))
+                            .delete("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, persistedShift.getId())
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json;charset=UTF-8"))
@@ -167,8 +170,8 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
     @Test
     public void deleteNonExistentShiftTest() throws Exception {
         mvc.perform(MockMvcRequestBuilders
-                .delete("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, 0)
-                .accept(MediaType.APPLICATION_JSON))
+                            .delete("/rest/tenant/{tenantId}/shift/{id}", TENANT_ID, 0)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json;charset=UTF-8"))
@@ -187,10 +190,10 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
         String body = (new ObjectMapper()).writeValueAsString(shiftView);
 
         mvc.perform(MockMvcRequestBuilders
-                .post("/rest/tenant/{tenantId}/shift/add", TENANT_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-                .accept(MediaType.APPLICATION_JSON))
+                            .post("/rest/tenant/{tenantId}/shift/add", TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.rotationEmployeeId").value(
@@ -220,10 +223,10 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
         String body = (new ObjectMapper()).writeValueAsString(updatedShift);
 
         mvc.perform(MockMvcRequestBuilders
-                .put("/rest/tenant/{tenantId}/shift/update", TENANT_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-                .accept(MediaType.APPLICATION_JSON))
+                            .put("/rest/tenant/{tenantId}/shift/update", TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.startDateTime").value(
@@ -234,6 +237,9 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
 
     @Test
     public void updateNonExistentShiftTest() throws Exception {
+        String exceptionMessage = "Shift entity with ID (0) not found.";
+        String exceptionClass = "javax.persistence.EntityNotFoundException";
+
         Spot spot = createSpot(TENANT_ID, "spot");
         LocalDateTime startDateTime = LocalDateTime.of(1999, 12, 31, 23, 59, 59, 0);
         LocalDateTime endDateTime = startDateTime.plusHours(10);
@@ -241,12 +247,13 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
         updatedShift.setId(0L);
         String body = (new ObjectMapper()).writeValueAsString(updatedShift);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .put("/rest/tenant/{tenantId}/shift/update", TENANT_ID)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)))
-                .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
-                        "Exception: Shift entity with ID (0) not found.");
+        mvc.perform(MockMvcRequestBuilders
+                            .put("/rest/tenant/{tenantId}/shift/update", TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 }

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillServiceTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillServiceTest.java
@@ -37,9 +37,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.NestedServletException;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -70,8 +68,8 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
     @Test
     public void getSkillListTest() throws Exception {
         mvc.perform(MockMvcRequestBuilders
-                .get("/rest/tenant/{tenantId}/skill/", TENANT_ID)
-                .accept(MediaType.APPLICATION_JSON))
+                            .get("/rest/tenant/{tenantId}/skill/", TENANT_ID)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk());
     }
@@ -82,8 +80,8 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
         Skill skill = skillService.createSkill(TENANT_ID, skillView);
 
         mvc.perform(MockMvcRequestBuilders
-                .get("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, skill.getId())
-                .accept(MediaType.APPLICATION_JSON))
+                            .get("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, skill.getId())
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.tenantId").value(TENANT_ID))
@@ -91,25 +89,35 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
     }
 
     @Test
-    public void getNonExistentSkillTest() {
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .get("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, 0)))
-                .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
-                        "Exception: No Skill entity found with ID (0).");
+    public void getNonExistentSkillTest() throws Exception {
+        String exceptionMessage = "No Skill entity found with ID (0).";
+        String exceptionClass = "javax.persistence.EntityNotFoundException";
+
+        mvc.perform(MockMvcRequestBuilders
+                            .get("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, 0)
+                            .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
-    public void getNonMatchingSkillTest() {
+    public void getNonMatchingSkillTest() throws Exception {
+        String exceptionMessage = "The tenantId (0) does not match the persistable (skill)'s tenantId (" +
+                TENANT_ID + ").";
+        String exceptionClass = "java.lang.IllegalStateException";
+
         SkillView skillView = new SkillView(TENANT_ID, "skill");
         Skill skill = skillService.createSkill(TENANT_ID, skillView);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .get("/rest/tenant/{tenantId}/skill/{id}", 0,
-                                skill.getId())))
-                .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: The " +
-                        "tenantId (0) does not match the persistable (skill)'s tenantId (" + TENANT_ID + ").");
+        mvc.perform(MockMvcRequestBuilders
+                            .get("/rest/tenant/{tenantId}/skill/{id}", 0, skill.getId())
+                            .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
@@ -118,8 +126,8 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
         Skill skill = skillService.createSkill(TENANT_ID, skillView);
 
         mvc.perform(MockMvcRequestBuilders
-                .delete("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, skill.getId())
-                .accept(MediaType.APPLICATION_JSON))
+                            .delete("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, skill.getId())
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json;charset=UTF-8"))
@@ -129,8 +137,8 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
     @Test
     public void deleteNonExistentSkillTest() throws Exception {
         mvc.perform(MockMvcRequestBuilders
-                .delete("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, 0)
-                .accept(MediaType.APPLICATION_JSON))
+                            .delete("/rest/tenant/{tenantId}/skill/{id}", TENANT_ID, 0)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/json;charset=UTF-8"))
@@ -138,15 +146,21 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
     }
 
     @Test
-    public void deleteNonMatchingSkillTest() {
+    public void deleteNonMatchingSkillTest() throws Exception {
+        String exceptionMessage = "The tenantId (0) does not match the persistable (skill)'s tenantId (" +
+                TENANT_ID + ").";
+        String exceptionClass = "java.lang.IllegalStateException";
+
         SkillView skillView = new SkillView(TENANT_ID, "skill");
         Skill skill = skillService.createSkill(TENANT_ID, skillView);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .delete("/rest/tenant/{tenantId}/skill/{id}", 0, skill.getId())))
-                .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: "
-                        + "The tenantId (0) does not match the persistable (skill)'s tenantId (" + TENANT_ID + ").");
+        mvc.perform(MockMvcRequestBuilders
+                            .delete("/rest/tenant/{tenantId}/skill/{id}", 0, skill.getId())
+                            .accept(MediaType.APPLICATION_JSON))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
@@ -155,10 +169,10 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
         String body = (new ObjectMapper()).writeValueAsString(skillView);
 
         mvc.perform(MockMvcRequestBuilders
-                .post("/rest/tenant/{tenantId}/skill/add", TENANT_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-                .accept(MediaType.APPLICATION_JSON))
+                            .post("/rest/tenant/{tenantId}/skill/add", TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.tenantId").value(TENANT_ID))
@@ -167,16 +181,21 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
 
     @Test
     public void createNonMatchingSkillTest() throws Exception {
+        String exceptionMessage = "The tenantId (0) does not match the persistable (skill)'s tenantId (" +
+                TENANT_ID + ").";
+        String exceptionClass = "java.lang.IllegalStateException";
+
         SkillView skillView = new SkillView(TENANT_ID, "skill");
         String body = (new ObjectMapper()).writeValueAsString(skillView);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .post("/rest/tenant/{tenantId}/skill/add", 0)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)))
-                .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: "
-                        + "The tenantId (0) does not match the persistable (skill)'s tenantId (" + TENANT_ID + ").");
+        mvc.perform(MockMvcRequestBuilders
+                            .post("/rest/tenant/{tenantId}/skill/add", 0)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
@@ -189,10 +208,10 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
         String body = (new ObjectMapper()).writeValueAsString(updatedSkill);
 
         mvc.perform(MockMvcRequestBuilders
-                .post("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-                .accept(MediaType.APPLICATION_JSON))
+                            .post("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body)
+                            .accept(MediaType.APPLICATION_JSON))
                 .andDo(mvcResult -> logger.info(mvcResult.toString()))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.tenantId").value(TENANT_ID))
@@ -201,39 +220,50 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
 
     @Test
     public void updateNonMatchingSkillTest() throws Exception {
+        String exceptionMessage = "The tenantId (0) does not match the persistable (updatedSkill)'s tenantId (" +
+                TENANT_ID + ").";
+        String exceptionClass = "java.lang.IllegalStateException";
+
         SkillView skillView = new SkillView(TENANT_ID, "skill");
         Skill skill = skillService.createSkill(TENANT_ID, skillView);
 
         SkillView updatedSkill = new SkillView(TENANT_ID, "updatedSkill");
         String body = (new ObjectMapper()).writeValueAsString(updatedSkill);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .post("/rest/tenant/{tenantId}/skill/update", 0)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)))
-                .withMessage("Request processing failed; nested exception is java.lang.IllegalStateException: "
-                        + "The tenantId (0) does not match the persistable (updatedSkill)'s tenantId (" + TENANT_ID +
-                        ").");
+        mvc.perform(MockMvcRequestBuilders
+                            .post("/rest/tenant/{tenantId}/skill/update", 0)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
     public void updateNonExistentSkillTest() throws Exception {
+        String exceptionMessage = "Skill entity with ID (0) not found.";
+        String exceptionClass = "javax.persistence.EntityNotFoundException";
+
         SkillView skillView = new SkillView(TENANT_ID, "skill");
         skillView.setId(0L);
         String body = (new ObjectMapper()).writeValueAsString(skillView);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .post("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)))
-                .withMessage("Request processing failed; nested exception is javax.persistence.EntityNotFound" +
-                        "Exception: Skill entity with ID (0) not found.");
+        mvc.perform(MockMvcRequestBuilders
+                            .post("/rest/tenant/{tenantId}/skill/update", TENANT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 
     @Test
     public void updateChangeTenantIdSkillTest() throws Exception {
+        String exceptionMessage = "Skill entity with tenantId (" + TENANT_ID + ") cannot change tenants.";
+        String exceptionClass = "java.lang.IllegalStateException";
+
         SkillView skillView = new SkillView(TENANT_ID, "skill");
         Skill skill = skillService.createSkill(TENANT_ID, skillView);
 
@@ -241,12 +271,13 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
         updatedSkill.setId(skill.getId());
         String body = (new ObjectMapper()).writeValueAsString(updatedSkill);
 
-        assertThatExceptionOfType(NestedServletException.class)
-                .isThrownBy(() -> mvc.perform(MockMvcRequestBuilders
-                        .post("/rest/tenant/{tenantId}/skill/update", 0)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)))
-                .withMessage("Request processing failed; nested exception is java.lang.IllegalState" +
-                        "Exception: Skill entity with tenantId (" + TENANT_ID + ") cannot change tenants.");
+        mvc.perform(MockMvcRequestBuilders
+                            .post("/rest/tenant/{tenantId}/skill/update", 0)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                .andDo(mvcResult -> logger.info(mvcResult.toString()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionMessage").value(exceptionMessage))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.exceptionClass").value(exceptionClass));
     }
 }

--- a/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/util/HierarchyTreeTest.java
+++ b/employee-rostering-backend/src/test/java/org/optaweb/employeerostering/util/HierarchyTreeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.util;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class HierarchyTreeTest {
+
+    private HierarchyTree<Integer, String> tested;
+
+    @Before
+    public void setup() {
+        // tested is the divisibility Hierarchy Tree;
+        // a is above b iff a divides b
+        tested = new HierarchyTree<>((a, b) -> {
+            if (a == b) {
+                return HierarchyTree.HierarchyRelationship.IS_THE_SAME_AS;
+            } else if (a % b == 0) {
+                return HierarchyTree.HierarchyRelationship.IS_BELOW;
+            } else if (b % a == 0) {
+                return HierarchyTree.HierarchyRelationship.IS_ABOVE;
+            } else {
+                return HierarchyTree.HierarchyRelationship.HAS_NO_DIRECT_RELATION;
+            }
+        });
+    }
+
+    @Test
+    public void testPutInHierarchyAndGetHierarchyClassValue() {
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(4));
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(6));
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(3));
+
+        tested.putInHierarchy(4, "4");
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
+        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
+        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(12));
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(3));
+
+        tested.putInHierarchy(12, "12");
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
+        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
+        assertEquals(Optional.of("12"), tested.getHierarchyClassValue(12));
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(3));
+
+        tested.putInHierarchy(3, "3");
+        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
+        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
+        assertEquals(Optional.of("12"), tested.getHierarchyClassValue(12));
+        assertEquals(Optional.of("3"), tested.getHierarchyClassValue(3));
+
+        tested.putInHierarchy(2, "2");
+        assertEquals(Optional.of("2"), tested.getHierarchyClassValue(2));
+        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
+        assertEquals(Optional.of("12"), tested.getHierarchyClassValue(12));
+        assertEquals(Optional.of("3"), tested.getHierarchyClassValue(3));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,23 @@
             </systemProperties>
           </configuration>
         </plugin>
+        <!--
+          Disable Jacoco check inherited from kie-parent. Remove this when it's removed from kie-parent
+          (but some projects still use the check fail build).
+        -->
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -647,7 +664,7 @@
         </pluginManagement>
       </build>
     </profile>
-    
+
     <profile>
       <id>sonar</id>
       <properties>


### PR DESCRIPTION
EDIT: Credits to @Christopher-Chianelli for configuring the `jacoco` build profile, and implementing Exception Handling for backend.

- Change backend `pom.xml` parent from `spring-boot-starter-parent` to `org.optaweb.employeerostering`, which has `kie-parent` as its parent
- Add `@Param` annotations to all Query methods in the repository classes
- Add ExceptionHandler for more specific frontend error messages
- Add API documentation on all REST methods with Swagger