### PR TITLE
PLANNER-1699: Fix UI Regressions; show score; add pin icon for pinned shifts

### DIFF
--- a/employee-rostering-frontend/src/setupTests.ts
+++ b/employee-rostering-frontend/src/setupTests.ts
@@ -23,8 +23,13 @@ configure({ adapter: new Adapter() });
 const mockDate = moment("2018-01-01", "YYYY-MM-DD").toDate();
 MockDate.set(mockDate);
 
-const mockTranslate = jest.fn().mockImplementation(k => `Trans(i18nKey=${k})`);
+const mockTranslate = jest.fn().mockImplementation((k,p) => `Trans(i18nKey=${k}${p? ", " + JSON.stringify(p) : ""})`);
 export { mockTranslate };
+
+// it appears await does not work with promises that have a then
+const flushPromises = () => new Promise(setImmediate);
+export { flushPromises };
+
 jest.mock('react-i18next', () => ({
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   withTranslation: () => (Component: any) => {

--- a/employee-rostering-frontend/src/store/roster/operations.ts
+++ b/employee-rostering-frontend/src/store/roster/operations.ts
@@ -40,21 +40,24 @@ import AvailabilityRosterView from 'domain/AvailabilityRosterView';
 import { employeeSelectors } from 'store/employee';
 import { spotSelectors } from 'store/spot';
 import { serializeLocalDate  } from 'store/rest/DataSerialization';
+import { getHardMediumSoftScoreFromString } from 'domain/HardMediumSoftScore';
 
 export interface RosterSliceInfo {
   fromDate: Date;
   toDate: Date;
 }
 
-interface KindaShiftRosterView extends Omit<ShiftRosterView, 'spotIdToShiftViewListMap'> {
+interface KindaShiftRosterView extends Omit<ShiftRosterView, 'spotIdToShiftViewListMap' | 'score'> {
   spotIdToShiftViewListMap: ObjectNumberMap<KindaShiftView[]>;
+  score: string;
 }
 
 interface KindaAvailabilityRosterView extends Omit<AvailabilityRosterView,
-'employeeIdToShiftViewListMap' | 'employeeIdToAvailabilityViewListMap' | 'unassignedShiftViewList' > {
+'employeeIdToShiftViewListMap' | 'employeeIdToAvailabilityViewListMap' | 'unassignedShiftViewList' | 'score' > {
   employeeIdToShiftViewListMap: ObjectNumberMap<KindaShiftView[]>;
   employeeIdToAvailabilityViewListMap: ObjectNumberMap<KindaEmployeeAvailabilityView[]>;
   unassignedShiftViewList: KindaShiftView[];
+  score: string;
 }
 
 let lastCalledShiftRosterArgs: any | null;
@@ -212,6 +215,7 @@ function convertKindaShiftRosterViewToShiftRosterView(newShiftRosterView: KindaS
     ...newShiftRosterView,
     spotIdToShiftViewListMap: mapObjectNumberMap(newShiftRosterView.spotIdToShiftViewListMap,
       shiftViewList => shiftViewList.map(kindaShiftViewAdapter)),
+    score: getHardMediumSoftScoreFromString(newShiftRosterView.score)
   };
 }
 
@@ -230,6 +234,7 @@ function convertKindaAvailabilityRosterViewToAvailabilityRosterView(
       ),
     ),
     unassignedShiftViewList: newAvailabilityRosterView.unassignedShiftViewList.map(kindaShiftViewAdapter),
+    score: getHardMediumSoftScoreFromString(newAvailabilityRosterView.score)
   };
 }
 

--- a/employee-rostering-frontend/src/store/roster/roster.test.ts
+++ b/employee-rostering-frontend/src/store/roster/roster.test.ts
@@ -32,6 +32,7 @@ import { availabilityRosterReducer } from './reducers';
 import DomainObjectView from 'domain/DomainObjectView';
 import RosterState from 'domain/RosterState';
 import { serializeLocalDate } from 'store/rest/DataSerialization';
+import { flushPromises } from 'setupTests';
 
 const mockShiftRoster: ShiftRosterView = {
   tenantId: 0,
@@ -91,6 +92,11 @@ const mockShiftRoster: ShiftRosterView = {
       },
       pinnedByUser: false
     }]
+  },
+  score: {
+    hardScore: 0,
+    mediumScore: 0,
+    softScore: 0
   }
 };
 
@@ -162,7 +168,12 @@ const mockAvailabilityRoster: AvailabilityRosterView = {
       state: "DESIRED"
     }]
   },
-  unassignedShiftViewList: []
+  unassignedShiftViewList: [],
+  score: {
+    hardScore: 0,
+    mediumScore: 0,
+    softScore: 0
+  }
 };
 
 describe('Roster operations', () => {
@@ -204,6 +215,7 @@ describe('Roster operations', () => {
 
     onPost(`/tenant/${tenantId}/roster/terminate`, {}, {});
     await(store.dispatch(rosterOperations.terminateSolvingRosterEarly()));
+    await flushPromises();
 
     expect(client.post).toHaveBeenCalledTimes(1);
     expect(client.post).toHaveBeenCalledWith(`/tenant/${tenantId}/roster/terminate`, {});
@@ -228,12 +240,12 @@ describe('Roster operations', () => {
 
       switch (method) {
         case 'get': {
-          onGet(restURL, { ...mockShiftRoster, spotIdToShiftViewListMap: {} });
+          onGet(restURL, { ...mockShiftRoster, spotIdToShiftViewListMap: {}, score: "0hard/0medium/0soft" });
           break;
         }
 
         case 'post': {
-          onPost(restURL, restArg, { ...mockShiftRoster, spotIdToShiftViewListMap: {} });
+          onPost(restURL, restArg, { ...mockShiftRoster, spotIdToShiftViewListMap: {}, score: "0hard/0medium/0soft" });
           break;
         }
       }
@@ -317,7 +329,8 @@ describe('Roster operations', () => {
           onGet(restURL, { 
             ...mockAvailabilityRoster,
             employeeIdToAvailabilityViewListMap: {},
-            employeeIdToShiftViewListMap: {}
+            employeeIdToShiftViewListMap: {},
+            score: "0hard/0medium/0soft"
           });
           break;
         }
@@ -326,7 +339,8 @@ describe('Roster operations', () => {
           onPost(restURL, restArg, { 
             ...mockAvailabilityRoster,
             employeeIdToAvailabilityViewListMap: {},
-            employeeIdToShiftViewListMap: {}
+            employeeIdToShiftViewListMap: {},
+            score: "0hard/0medium/0soft"
           });
           break;
         }
@@ -459,7 +473,7 @@ describe('Roster operations', () => {
     
     onPost(`/tenant/${tenantId}/roster/shiftRosterView/for?` +
     `&startDate=${serializeLocalDate(fromDate)}&endDate=${serializeLocalDate(moment(toDate).add(1, "day").toDate())}`,
-    spotList, { ...mockShiftRoster, spotIdToShiftViewListMap: {} });
+    spotList, { ...mockShiftRoster, spotIdToShiftViewListMap: {}, score: "0hard/0medium/0soft" });
     await store.dispatch(rosterOperations.getInitialShiftRoster());
 
     expect(store.getActions()).toEqual([
@@ -517,7 +531,11 @@ describe('Roster operations', () => {
     };
     
     onGet(`/tenant/${tenantId}/roster/shiftRosterView/current?p=${pagination.pageNumber}` + 
-    `&n=${pagination.itemsPerPage}`, { ...mockShiftRoster, spotIdToShiftViewListMap: {} });
+    `&n=${pagination.itemsPerPage}`, { 
+      ...mockShiftRoster,
+      spotIdToShiftViewListMap: {},
+      score: "0hard/0medium/0soft" 
+    });
     await store.dispatch(rosterOperations.getCurrentShiftRoster(pagination));
 
     expect(store.getActions()).toEqual([
@@ -547,7 +565,8 @@ describe('Roster operations', () => {
     `&startDate=${serializeLocalDate(fromDate)}&` + 
     `endDate=${serializeLocalDate(moment(toDate).add(1, "day").toDate())}`, {
       ...mockShiftRoster,
-      spotIdToShiftViewListMap: {}
+      spotIdToShiftViewListMap: {},
+      score: "0hard/0medium/0soft"
     });
     await store.dispatch(rosterOperations.getShiftRoster({
       fromDate: fromDate,
@@ -578,7 +597,7 @@ describe('Roster operations', () => {
     
     onPost(`/tenant/${tenantId}/roster/shiftRosterView/for?` +
     `&startDate=${serializeLocalDate(fromDate)}&endDate=${serializeLocalDate(moment(toDate).add(1, "day").toDate())}`,
-    spotList, { ...mockShiftRoster, spotIdToShiftViewListMap: {} });
+    spotList, { ...mockShiftRoster, spotIdToShiftViewListMap: {}, score: "0hard/0medium/0soft" });
     await store.dispatch(rosterOperations.getShiftRosterFor({
       fromDate: fromDate,
       toDate: toDate,
@@ -611,7 +630,8 @@ describe('Roster operations', () => {
     employeeList, {
       ...mockAvailabilityRoster,
       employeeIdToShiftViewListMap: {},
-      employeeIdToAvailabilityViewListMap: {}
+      employeeIdToAvailabilityViewListMap: {},
+      score: "0hard/0medium/0soft"
     });
     await store.dispatch(rosterOperations.getInitialAvailabilityRoster());
 
@@ -678,7 +698,8 @@ describe('Roster operations', () => {
     `&n=${pagination.itemsPerPage}`, {
       ...mockAvailabilityRoster,
       employeeIdToShiftViewListMap: {},
-      employeeIdToAvailabilityViewListMap: {}
+      employeeIdToAvailabilityViewListMap: {},
+      score: "0hard/0medium/0soft"
     });
     await store.dispatch(rosterOperations.getCurrentAvailabilityRoster(pagination));
 
@@ -714,7 +735,8 @@ describe('Roster operations', () => {
     `&endDate=${serializeLocalDate(moment(toDate).add(1, "day").toDate())}`, { 
       ...mockAvailabilityRoster,
       employeeIdToShiftViewListMap: {},
-      employeeIdToAvailabilityViewListMap: {}
+      employeeIdToAvailabilityViewListMap: {},
+      score: "0hard/0medium/0soft"
     });
     await store.dispatch(rosterOperations.getAvailabilityRoster({
       fromDate: fromDate,
@@ -750,7 +772,8 @@ describe('Roster operations', () => {
     employeeList, {
       ...mockAvailabilityRoster,
       employeeIdToShiftViewListMap: {},
-      employeeIdToAvailabilityViewListMap: {}
+      employeeIdToAvailabilityViewListMap: {},
+      score: "0hard/0medium/0soft"
     });
     await store.dispatch(rosterOperations.getAvailabilityRosterFor({
       fromDate: fromDate,

--- a/employee-rostering-frontend/src/store/tenant/tenant.test.ts
+++ b/employee-rostering-frontend/src/store/tenant/tenant.test.ts
@@ -36,6 +36,7 @@ import moment from 'moment';
 import { shiftTemplateOperations } from 'store/rotation';
 import RosterState from 'domain/RosterState';
 import * as immutableOperations from 'util/ImmutableCollectionOperations';
+import { flushPromises } from 'setupTests';
 
 describe('Tenant operations', () => {
   const mockRefreshSkillList = jest.spyOn(skillOperations, "refreshSkillList");
@@ -103,6 +104,7 @@ describe('Tenant operations', () => {
       onGet(`/tenant/`, mockTenantList);
     
       await store.dispatch(tenantOperations.refreshTenantList());
+      await flushPromises();
     
       expect(store.getActions()).toEqual(expect.arrayContaining([
         actions.refreshTenantList({currentTenantId: 1, tenantList: mockTenantList}),
@@ -145,6 +147,7 @@ describe('Tenant operations', () => {
       mockTenantList[1].id = 0;
 
       await store.dispatch(tenantOperations.refreshTenantList());
+      await flushPromises();
 
       expect(store.getActions()).toEqual(expect.arrayContaining([
         actions.refreshTenantList({currentTenantId: 0, tenantList: mockTenantList}),
@@ -284,6 +287,7 @@ describe('Tenant operations', () => {
     onGet(`/tenant/`, mockTenantList);
 
     await store.dispatch(tenantOperations.refreshTenantList());
+    await flushPromises();
 
     expect(store.getActions()).toEqual(expect.arrayContaining([
       actions.refreshTenantList({currentTenantId: 0, tenantList: mockTenantList}),

--- a/employee-rostering-frontend/src/ui/components/ScoreDisplay.test.tsx
+++ b/employee-rostering-frontend/src/ui/components/ScoreDisplay.test.tsx
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { ScoreDisplay } from './ScoreDisplay';
+import HardMediumSoftScore from 'domain/HardMediumSoftScore';
 
-import Employee from './Employee';
-import RosterState from './RosterState';
-import Spot from './Spot';
-import HardMediumSoftScore from './HardMediumSoftScore';
-
-export default interface RosterView {
-  tenantId: number;
-  startDate: string;
-  endDate: string;
-  score: HardMediumSoftScore;
-  spotList: Spot[];
-  employeeList: Employee[];
-  rosterState: RosterState;
-}
+describe('ScoreDisplay component', () => {
+  it('should renderCorrectly', () => {
+    const score: HardMediumSoftScore = {
+      hardScore: -10,
+      mediumScore: -5,
+      softScore: 20
+    };
+    const scoreDisplay = shallow(<ScoreDisplay score={score} />);
+    expect(scoreDisplay).toMatchSnapshot();
+  });
+});

--- a/employee-rostering-frontend/src/ui/components/ScoreDisplay.tsx
+++ b/employee-rostering-frontend/src/ui/components/ScoreDisplay.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import HardMediumSoftScore from 'domain/HardMediumSoftScore';
+import { Chip } from '@patternfly/react-core';
+
+export interface ScoreDisplayProps {
+  score: HardMediumSoftScore;
+}
+
+export const ScoreDisplay: React.FC<ScoreDisplayProps> = (props) => {
+  const { t } = useTranslation("ScoreDisplay");
+  const { hardScore, mediumScore, softScore } = props.score;
+  return (
+    <span>
+      <Chip isReadOnly>
+        {t("hardScore", { hardScore })}
+      </Chip>
+      <Chip isReadOnly>
+        {t("mediumScore", { mediumScore })}
+      </Chip>
+      <Chip isReadOnly>
+        {t("softScore", { softScore })}
+      </Chip>
+    </span>
+  );
+};

--- a/employee-rostering-frontend/src/ui/components/__snapshots__/ScoreDisplay.test.tsx.snap
+++ b/employee-rostering-frontend/src/ui/components/__snapshots__/ScoreDisplay.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScoreDisplay component should renderCorrectly 1`] = `
+<span>
+  <Chip
+    className=""
+    closeBtnAriaLabel="close"
+    component="div"
+    isOverflowChip={false}
+    isReadOnly={true}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    Trans(i18nKey=hardScore, {"hardScore":-10})
+  </Chip>
+  <Chip
+    className=""
+    closeBtnAriaLabel="close"
+    component="div"
+    isOverflowChip={false}
+    isReadOnly={true}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    Trans(i18nKey=mediumScore, {"mediumScore":-5})
+  </Chip>
+  <Chip
+    className=""
+    closeBtnAriaLabel="close"
+    component="div"
+    isOverflowChip={false}
+    isReadOnly={true}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    Trans(i18nKey=softScore, {"softScore":20})
+  </Chip>
+</span>
+`;

--- a/employee-rostering-frontend/src/ui/components/__snapshots__/ServerSideExceptionDialog.test.tsx.snap
+++ b/employee-rostering-frontend/src/ui/components/__snapshots__/ServerSideExceptionDialog.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ServerSideExceptionDialog should render an ServerSideException Alert correctly 1`] = `
 <Fragment>
-  Trans(i18nKey=error1)
+  Trans(i18nKey=error1, ["hi"])
   <Button
     aria-label="Show Stack Trace"
     onClick={[Function]}
@@ -78,7 +78,7 @@ exports[`ServerSideExceptionDialog should render an ServerSideException Alert co
 
 exports[`ServerSideExceptionDialog should render an ServerSideException Modal correctly 1`] = `
 <Fragment>
-  Trans(i18nKey=error1)
+  Trans(i18nKey=error1, ["hi"])
   <Button
     aria-label="Show Stack Trace"
     onClick={[Function]}

--- a/employee-rostering-frontend/src/ui/components/calendar/ReactBigCalendarOverrides.css
+++ b/employee-rostering-frontend/src/ui/components/calendar/ReactBigCalendarOverrides.css
@@ -96,7 +96,7 @@
 }
 
 .unavailable .rbc-time-slot {
-    border-top: 1px solid black;
+    border-top: none;
     background-color: var(--pf-global--danger-color--100);
 }
 
@@ -109,7 +109,7 @@
 }
 
 .undesired .rbc-time-slot {
-    border-top: 1px solid black;
+    border-top: none;
     background-color: var(--pf-global--warning-color--100);
 }
 
@@ -122,7 +122,7 @@
 }
 
 .desired .rbc-time-slot {
-    border-top: 1px solid black;
+    border-top: none;
     background-color: var(--pf-global--success-color--200);
 }
 

--- a/employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
+++ b/employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
@@ -44,6 +44,8 @@ import {
 } from 'react-router-dom';
 import { withTranslation, WithTranslation, Trans } from 'react-i18next';
 import Actions from 'ui/components/Actions';
+import HardMediumSoftScore from 'domain/HardMediumSoftScore';
+import { ScoreDisplay } from 'ui/components/ScoreDisplay';
 
 interface StateProps {
   isSolving: boolean;
@@ -56,6 +58,7 @@ interface StateProps {
   endDate: Date | null;
   totalNumOfSpots: number;
   rosterState: RosterState | null;
+  score: HardMediumSoftScore | null;
 }
 
 // Snapshot of the last value to show when loading
@@ -87,6 +90,7 @@ const mapStateToProps = (state: AppState): StateProps => ({
     ? moment(state.availabilityRoster.availabilityRosterView.endDate).toDate() : null,
   totalNumOfSpots: spotSelectors.getSpotList(state).length,
   rosterState: state.rosterState.rosterState,
+  score: state.availabilityRoster.availabilityRosterView? state.availabilityRoster.availabilityRosterView.score : null
 });
 
 export interface DispatchProps {
@@ -284,6 +288,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
     const startDate = this.props.startDate as Date;
     const endDate = this.props.endDate as Date;
     const shownEmployee = this.props.shownEmployeeList[0];
+    const score: HardMediumSoftScore = this.props.score || { hardScore: 0, mediumScore: 0, softScore: 0 };
     const events: ShiftOrAvailability[] = [];
     const actions = [
       { name: t("publish"), action: this.props.publishRoster },
@@ -333,7 +338,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
             display: "grid",
             height: '60px',
             padding: '5px 5px 5px 5px',
-            gridTemplateColumns: 'auto auto 1fr',
+            gridTemplateColumns: 'auto auto auto 1fr',
             backgroundColor: 'var(--pf-global--BackgroundColor--100)',
           }}
         >
@@ -351,6 +356,7 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
             value={this.props.startDate as Date}
             onChange={this.onDateChange}
           />
+          <ScoreDisplay score={score} />
           <Actions
             actions={actions}
           />

--- a/employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
+++ b/employee-rostering-frontend/src/ui/pages/availability/__snapshots__/AvailabilityRosterPage.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Availability Roster Page should render correctly when creating a new av
       Object {
         "backgroundColor": "var(--pf-global--BackgroundColor--100)",
         "display": "grid",
-        "gridTemplateColumns": "auto auto 1fr",
+        "gridTemplateColumns": "auto auto auto 1fr",
         "height": "60px",
         "padding": "5px 5px 5px 5px",
       }
@@ -78,6 +78,15 @@ exports[`Availability Roster Page should render correctly when creating a new av
       aria-label="Select Week to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
+    />
+    <ScoreDisplay
+      score={
+        Object {
+          "hardScore": 0,
+          "mediumScore": 0,
+          "softScore": 0,
+        }
+      }
     />
     <SizeMe(Actions)
       actions={
@@ -270,7 +279,7 @@ exports[`Availability Roster Page should render correctly when loaded 1`] = `
       Object {
         "backgroundColor": "var(--pf-global--BackgroundColor--100)",
         "display": "grid",
-        "gridTemplateColumns": "auto auto 1fr",
+        "gridTemplateColumns": "auto auto auto 1fr",
         "height": "60px",
         "padding": "5px 5px 5px 5px",
       }
@@ -341,6 +350,15 @@ exports[`Availability Roster Page should render correctly when loaded 1`] = `
       aria-label="Select Week to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
+    />
+    <ScoreDisplay
+      score={
+        Object {
+          "hardScore": 0,
+          "mediumScore": 0,
+          "softScore": 0,
+        }
+      }
     />
     <SizeMe(Actions)
       actions={
@@ -561,7 +579,7 @@ exports[`Availability Roster Page should render correctly when solving 1`] = `
       Object {
         "backgroundColor": "var(--pf-global--BackgroundColor--100)",
         "display": "grid",
-        "gridTemplateColumns": "auto auto 1fr",
+        "gridTemplateColumns": "auto auto auto 1fr",
         "height": "60px",
         "padding": "5px 5px 5px 5px",
       }
@@ -632,6 +650,15 @@ exports[`Availability Roster Page should render correctly when solving 1`] = `
       aria-label="Select Week to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
+    />
+    <ScoreDisplay
+      score={
+        Object {
+          "hardScore": 0,
+          "mediumScore": 0,
+          "softScore": 0,
+        }
+      }
     />
     <SizeMe(Actions)
       actions={

--- a/employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.test.tsx
+++ b/employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.test.tsx
@@ -240,6 +240,13 @@ describe('ShiftEvent', () => {
     );
     expect(toJson(shiftEventObj)).toMatchSnapshot();
   });
+
+  it('should render ShiftEvent correctly when pinned', () => {
+    const shiftEventObj = shallow(
+      <ShiftEvent event={{...baseShift, pinnedByUser: true}} title="Employee" />
+    );
+    expect(toJson(shiftEventObj)).toMatchSnapshot();
+  });
 });
 
 const spot: Spot = {

--- a/employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.tsx
+++ b/employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.tsx
@@ -20,7 +20,7 @@ import { Text, Button, ButtonVariant, List } from "@patternfly/react-core";
 import moment from "moment";
 import Employee from "domain/Employee";
 import { convertHardMediumSoftScoreToString } from 'domain/HardMediumSoftScore';
-import { EditIcon, TrashIcon } from "@patternfly/react-icons";
+import { EditIcon, TrashIcon, ThumbTackIcon } from "@patternfly/react-icons";
 import Color from 'color';
 import { useTranslation } from 'react-i18next';
 
@@ -311,6 +311,7 @@ const ShiftEvent: React.FC<EventProps<Shift>> = (props) => (
       width: "100%"
     }}
   >
+    {props.event.pinnedByUser && <ThumbTackIcon />}
     {props.title}
   </span>
 );

--- a/employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
+++ b/employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
@@ -40,6 +40,8 @@ import { CubesIcon } from '@patternfly/react-icons';
 import { withTranslation, WithTranslation, Trans } from 'react-i18next';
 import "ui/components/TypeaheadSelectInput.css";
 import Actions from "ui/components/Actions";
+import HardMediumSoftScore from "domain/HardMediumSoftScore";
+import { ScoreDisplay } from "ui/components/ScoreDisplay";
 
 interface StateProps {
   isSolving: boolean;
@@ -51,6 +53,7 @@ interface StateProps {
   endDate: Date | null;
   totalNumOfSpots: number;
   rosterState: RosterState | null;
+  score: HardMediumSoftScore | null;
 }
 
 // Snapshot of the last value to show when loading
@@ -73,6 +76,7 @@ const mapStateToProps = (state: AppState): StateProps => ({
   endDate: (state.shiftRoster.shiftRosterView) ? moment(state.shiftRoster.shiftRosterView.endDate).toDate() : null,
   totalNumOfSpots: spotSelectors.getSpotList(state).length,
   rosterState: state.rosterState.rosterState,
+  score: state.shiftRoster.shiftRosterView? state.shiftRoster.shiftRosterView.score : null
 });
 
 export interface DispatchProps {
@@ -224,6 +228,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
     const startDate = this.props.startDate as Date;
     const endDate = this.props.endDate as Date;
     const shownSpot = this.props.shownSpotList[0];
+    const score: HardMediumSoftScore = this.props.score || { hardScore: 0, mediumScore: 0, softScore: 0 }; 
     const actions = [
       { name: t("publish"), action: this.props.publishRoster },
       { name: this.props.isSolving? t("terminateEarly") : t("schedule"),
@@ -248,7 +253,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
             display: "grid",
             height: '60px',
             padding: '5px 5px 5px 5px',
-            gridTemplateColumns: 'auto auto 1fr',
+            gridTemplateColumns: 'auto auto auto 1fr',
             backgroundColor: 'var(--pf-global--BackgroundColor--100)',
           }}
         >
@@ -266,6 +271,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
             value={this.props.startDate as Date}
             onChange={this.onDateChange}
           />
+          <ScoreDisplay score={score} />
           <Actions
             actions={actions}
           />

--- a/employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftEvent.test.tsx.snap
+++ b/employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftEvent.test.tsx.snap
@@ -230,30 +230,30 @@ exports[`ShiftEvent getContractMinutesViolations should render correctly 1`] = `
   <li
     key="0"
   >
-    Trans(i18nKey=exceededContractMaximumMinutes)
+    Trans(i18nKey=exceededContractMaximumMinutes, {"employee":"Employee 1","durationly":"Trans(i18nKey=daily)","duration":"Trans(i18nKey=day)","minutesWorked":20,"maxMinutesAllowed":10})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
   <li
     key="1"
   >
-    Trans(i18nKey=exceededContractMaximumMinutes)
+    Trans(i18nKey=exceededContractMaximumMinutes, {"employee":"Employee 1","durationly":"Trans(i18nKey=weekly)","duration":"Trans(i18nKey=week)","minutesWorked":80,"maxMinutesAllowed":70})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
   <li
     key="2"
   >
-    Trans(i18nKey=exceededContractMaximumMinutes)
+    Trans(i18nKey=exceededContractMaximumMinutes, {"employee":"Employee 1","durationly":"Trans(i18nKey=monthly)","duration":"Trans(i18nKey=month)","minutesWorked":600,"maxMinutesAllowed":500})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
   <li
     key="3"
   >
-    Trans(i18nKey=exceededContractMaximumMinutes)
+    Trans(i18nKey=exceededContractMaximumMinutes, {"employee":"Employee 1","durationly":"Trans(i18nKey=yearly)","duration":"Trans(i18nKey=year)","minutesWorked":7000,"maxMinutesAllowed":6000})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
 </ContractMinutesViolations>
 `;
@@ -478,9 +478,9 @@ exports[`ShiftEvent getDesiredTimeslotForEmployeeReward should render correctly 
   <li
     key="0"
   >
-    Trans(i18nKey=desiredShiftForEmployee)
+    Trans(i18nKey=desiredShiftForEmployee, {"employee":"Employee 1","from":"July 1, 2018 9:00 AM","to":"July 1, 2018 9:00 AM"})
     <br />
-    Trans(i18nKey=reward)
+    Trans(i18nKey=reward, {"score":"-1 Soft"})
   </li>
 </DesiredTimeslotForEmployeeRewards>
 `;
@@ -1055,7 +1055,7 @@ exports[`ShiftEvent getIndictments should render correctly with indictments 1`] 
         <li
           key="0"
         >
-          Trans(i18nKey=missingRequiredSkills)
+          Trans(i18nKey=missingRequiredSkills, {"employee":"Employee 1","spot":"Spot"})
           <List>
             <ul
               className="pf-c-list"
@@ -1067,7 +1067,7 @@ exports[`ShiftEvent getIndictments should render correctly with indictments 1`] 
               </li>
             </ul>
           </List>
-          Trans(i18nKey=penalty)
+          Trans(i18nKey=penalty, {"score":"-10 Hard"})
         </li>
       </RequiredSkillViolations>
       <ContractMinutesViolations
@@ -2458,9 +2458,9 @@ exports[`ShiftEvent getIndictments should render correctly with indictments 1`] 
         <li
           key="1"
         >
-          Trans(i18nKey=employeeDoesNotMatchRotationEmployee)
+          Trans(i18nKey=employeeDoesNotMatchRotationEmployee, {"employee":"Employee 1","rotationEmployee":"Rotation Employee"})
           <br />
-          Trans(i18nKey=penalty)
+          Trans(i18nKey=penalty, {"score":"-100 Soft"})
         </li>
       </RotationViolationPenalties>
       <UndesiredTimeslotForEmployeePenalties
@@ -4047,7 +4047,7 @@ exports[`ShiftEvent getRequiredSkillViolations should render correctly 1`] = `
   <li
     key="0"
   >
-    Trans(i18nKey=missingRequiredSkills)
+    Trans(i18nKey=missingRequiredSkills, {"employee":"Employee 1","spot":"Spot"})
     <List>
       <ul
         className="pf-c-list"
@@ -4059,7 +4059,7 @@ exports[`ShiftEvent getRequiredSkillViolations should render correctly 1`] = `
         </li>
       </ul>
     </List>
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-10 Hard"})
   </li>
 </RequiredSkillViolations>
 `;
@@ -4252,9 +4252,9 @@ exports[`ShiftEvent getRotationViolationPenalties should render correctly 1`] = 
   <li
     key="1"
   >
-    Trans(i18nKey=employeeDoesNotMatchRotationEmployee)
+    Trans(i18nKey=employeeDoesNotMatchRotationEmployee, {"employee":"Employee 1","rotationEmployee":"Rotation Employee"})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-100 Soft"})
   </li>
 </RotationViolationPenalties>
 `;
@@ -4713,16 +4713,16 @@ exports[`ShiftEvent getShiftEmployeeConflictViolations should render correctly 1
   <li
     key="0"
   >
-    Trans(i18nKey=conflictingShifts)
+    Trans(i18nKey=conflictingShifts, {"employee":"Employee 1","spot":"Spot","from":"10:00 AM","to":"5:00 PM"})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
   <li
     key="1"
   >
-    Trans(i18nKey=conflictingShifts)
+    Trans(i18nKey=conflictingShifts, {"employee":"Employee 1","spot":"Spot","from":"8:00 AM","to":"5:00 PM"})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
 </ShiftEmployeeConflictViolations>
 `;
@@ -4917,7 +4917,7 @@ exports[`ShiftEvent getUnassignedShiftPenalties should render correctly 1`] = `
   >
     Trans(i18nKey=unassignedShift)
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Medium"})
   </li>
 </UnassignedShiftPenalties>
 `;
@@ -5142,9 +5142,9 @@ exports[`ShiftEvent getUnavaliableEmployeeViolations should render correctly 1`]
   <li
     key="0"
   >
-    Trans(i18nKey=unavailableEmployee)
+    Trans(i18nKey=unavailableEmployee, {"employee":"Employee 1","from":"July 1, 2018 9:00 AM","to":"July 1, 2018 9:00 AM"})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Hard"})
   </li>
 </UnavailableEmployeeViolations>
 `;
@@ -5369,9 +5369,9 @@ exports[`ShiftEvent getUndesiredTimeslotForEmployeePenalties should render corre
   <li
     key="0"
   >
-    Trans(i18nKey=undesiredShiftForEmployee)
+    Trans(i18nKey=undesiredShiftForEmployee, {"employee":"Employee 1","from":"July 1, 2018 9:00 AM","to":"July 1, 2018 9:00 AM"})
     <br />
-    Trans(i18nKey=penalty)
+    Trans(i18nKey=penalty, {"score":"-1 Soft"})
   </li>
 </UndesiredTimeslotForEmployeePenalties>
 `;
@@ -5390,6 +5390,26 @@ exports[`ShiftEvent should render ShiftEvent correctly 1`] = `
 </span>
 `;
 
+exports[`ShiftEvent should render ShiftEvent correctly when pinned 1`] = `
+<span
+  style={
+    Object {
+      "display": "flex",
+      "height": "100%",
+      "width": "100%",
+    }
+  }
+>
+  <ThumbTackIcon
+    color="currentColor"
+    noVerticalAlign={false}
+    size="sm"
+    title={null}
+  />
+  Employee
+</span>
+`;
+
 exports[`ShiftEvent should render ShiftPopupBody correctly 1`] = `
 <span
   style={
@@ -5401,7 +5421,7 @@ exports[`ShiftEvent should render ShiftPopupBody correctly 1`] = `
     }
   }
 >
-  Trans(i18nKey=totalIndictment)
+  Trans(i18nKey=totalIndictment, {"score":"0"})
   <br />
   <Indictments
     contractMinutesViolationPenaltyList={Array []}

--- a/employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
+++ b/employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
       Object {
         "backgroundColor": "var(--pf-global--BackgroundColor--100)",
         "display": "grid",
-        "gridTemplateColumns": "auto auto 1fr",
+        "gridTemplateColumns": "auto auto auto 1fr",
         "height": "60px",
         "padding": "5px 5px 5px 5px",
       }
@@ -58,6 +58,15 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
       aria-label="Select Week to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
+    />
+    <ScoreDisplay
+      score={
+        Object {
+          "hardScore": 0,
+          "mediumScore": 0,
+          "softScore": 0,
+        }
+      }
     />
     <SizeMe(Actions)
       actions={
@@ -201,7 +210,7 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
       Object {
         "backgroundColor": "var(--pf-global--BackgroundColor--100)",
         "display": "grid",
-        "gridTemplateColumns": "auto auto 1fr",
+        "gridTemplateColumns": "auto auto auto 1fr",
         "height": "60px",
         "padding": "5px 5px 5px 5px",
       }
@@ -252,6 +261,15 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
       aria-label="Select Week to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
+    />
+    <ScoreDisplay
+      score={
+        Object {
+          "hardScore": 0,
+          "mediumScore": 0,
+          "softScore": 0,
+        }
+      }
     />
     <SizeMe(Actions)
       actions={
@@ -423,7 +441,7 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
       Object {
         "backgroundColor": "var(--pf-global--BackgroundColor--100)",
         "display": "grid",
-        "gridTemplateColumns": "auto auto 1fr",
+        "gridTemplateColumns": "auto auto auto 1fr",
         "height": "60px",
         "padding": "5px 5px 5px 5px",
       }
@@ -474,6 +492,15 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
       aria-label="Select Week to View"
       onChange={[Function]}
       value={2018-07-01T00:00:00.000Z}
+    />
+    <ScoreDisplay
+      score={
+        Object {
+          "hardScore": 0,
+          "mediumScore": 0,
+          "softScore": 0,
+        }
+      }
     />
     <SizeMe(Actions)
       actions={

--- a/employee-rostering-frontend/translations/en/ScoreDisplay.yaml
+++ b/employee-rostering-frontend/translations/en/ScoreDisplay.yaml
@@ -1,0 +1,4 @@
+---
+hardScore: "Hard: {{hardScore}}"
+mediumScore: "Medium: {{mediumScore}}"
+softScore: "Soft: {{softScore}}"


### PR DESCRIPTION
Note: I modified the mock translate to also show the params passed
to translate (so the test can verify the correct params are passed into
translate, instead of only verifying the key). This modified some
of the other snapshots.

Another note: for missing translations when the language is set to cmn (or any other language), it will use the English translation as a fallback. 