### PR TITLE
Remove a benchmark config that cause GC Overhead exception ONLY on my machine

### DIFF
--- a/employee-rostering-benchmark/src/main/resources/employeeRosteringBenchmarkConfig.xml
+++ b/employee-rostering-benchmark/src/main/resources/employeeRosteringBenchmarkConfig.xml
@@ -25,6 +25,9 @@
     </solver>
   </solverBenchmark>
 
+  <!-- A GC Overhead Limit occurs on machines with 24 threads  -->
+  <!-- Machines with 8 threads do not seem to be affected -->
+  <!--
   <solverBenchmark>
     <name>Move Selector and Pillar Move Selector</name>
     <solver>
@@ -38,6 +41,7 @@
       </localSearch>
     </solver>
   </solverBenchmark>
+  -->
 
   <solverBenchmark>
     <name>Move Selector and Sequential Pillar Move Selector</name>


### PR DESCRIPTION
The odd thing is my machine is fairly powerful:

- 12 cores, 24 threads
- 32 GB RAM

And it works on machines with less cores and less RAM than it.

VM max memory (as in -Xmx but lower): 954,728,448 bytes