### PR TITLE
Add a .eslintignore to ignore files in cypress/.gitignore

### DIFF
--- a/employee-rostering-frontend/.eslintignore
+++ b/employee-rostering-frontend/.eslintignore
@@ -1,0 +1,3 @@
+cypress/screenshots/**
+cypress/support/**
+cypress/videos/**


### PR DESCRIPTION
Some auto-generated .gitignore files are being linted, causing errors. This make eslint also ignore them.