### PR TITLE
BXMSPROD-580: frontend-maven-plugin version pointing to the centralised one

### DIFF
--- a/employee-rostering-frontend/pom.xml
+++ b/employee-rostering-frontend/pom.xml
@@ -35,15 +35,6 @@
   </properties>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.github.eirslett</groupId>
-          <artifactId>frontend-maven-plugin</artifactId>
-          <version>${version.frontend-maven-plugin}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>com.github.eirslett</groupId>

--- a/employee-rostering-frontend/pom.xml
+++ b/employee-rostering-frontend/pom.xml
@@ -30,17 +30,24 @@
   <description>React frontend for Employee Rostering as a Service</description>
 
   <properties>
-    <frontend-maven-plugin.version>1.7.5</frontend-maven-plugin.version>
     <node.version>v8.12.0</node.version>
     <npm.version>6.9.0</npm.version>
   </properties>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.github.eirslett</groupId>
+          <artifactId>frontend-maven-plugin</artifactId>
+          <version>${version.frontend-maven-plugin}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>${frontend-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>install node and npm</id>


### PR DESCRIPTION
Requires: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1117

BXMSPROD-580