### PR TITLE
[DO NOT MERGE] Place all frontend test reports in a single subdirectory

### DIFF
--- a/employee-rostering-frontend/cypress.json
+++ b/employee-rostering-frontend/cypress.json
@@ -2,6 +2,6 @@
     "baseUrl": "http://localhost:3000",
     "reporter": "junit",
     "reporterOptions": {
-        "mochaFile": "target/TEST-cypress.xml"
+        "mochaFile": "target/test-reports/TEST-cypress.xml"
     }
 }

--- a/employee-rostering-frontend/cypress.json
+++ b/employee-rostering-frontend/cypress.json
@@ -2,6 +2,7 @@
     "baseUrl": "http://localhost:3000",
     "reporter": "junit",
     "reporterOptions": {
-        "mochaFile": "target/test-reports/TEST-cypress.xml"
+        "mochaFile": "target/test-reports/TEST-cypress.xml",
+        "jenkinsMode": true
     }
 }

--- a/employee-rostering-frontend/package.json
+++ b/employee-rostering-frontend/package.json
@@ -49,7 +49,7 @@
     "cypress:run": "cypress run"
   },
   "jest-junit": {
-    "outputDirectory": "./target/surefire-reports",
+    "outputDirectory": "./target/test-reports",
     "outputName": "TEST-frontend.xml",
     "suiteName": "org.optaweb.employeerostering.frontend.tests",
     "suiteNameTemplate": "{filepath}",


### PR DESCRIPTION
Jenkins jobs expect test results to be stored in
**/target/-reports/TEST-.xml

The same change goes into VRP as well:
https://github.com/kiegroup/optaweb-vehicle-routing/pull/229