### PR TITLE
Add excluded JAXB dependencies for Java 11

### DIFF
--- a/employee-rostering-backend/pom.xml
+++ b/employee-rostering-backend/pom.xml
@@ -67,6 +67,10 @@
           <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -109,6 +113,24 @@
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
+    </dependency>
+
+    <!-- Required for Java 11 -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
     </dependency>
 
     <!-- Testing dependencies -->


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/PLANNER-1727

Fixes `Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException` exception when run on Java 11.