### PR TITLE
RHDM-1129: locktt execution added to productized profile, prepare-package phase

### DIFF
--- a/employee-rostering-frontend/pom.xml
+++ b/employee-rostering-frontend/pom.xml
@@ -196,6 +196,34 @@
         <sonar.typescript.lcov.reportPaths>coverage/lcov.info</sonar.typescript.lcov.reportPaths>
       </properties>
     </profile>
+    <profile>
+      <id>productized</id>
+      <activation>
+        <property>
+          <name>productized</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>locktt final cleanup</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>run locktt</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/RHDM-1129

depends on
- https://issues.jboss.org/browse/BXMSPROD-597 https://github.com/kiegroup/optaweb-employee-rostering/pull/336
- and https://issues.jboss.org/browse/BXMSPROD-580 https://github.com/kiegroup/optaweb-employee-rostering/pull/330
