### PR TITLE
PLANNER-1732: Give Airbnb config highest priority

### DIFF
--- a/employee-rostering-frontend/.eslintrc.json
+++ b/employee-rostering-frontend/.eslintrc.json
@@ -24,11 +24,11 @@
     ]
   },
   "extends": [
-    "airbnb",
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
-    "react-app"
+    "react-app",
+    "airbnb"
   ],
   "rules": {
     // New rules added by updating package-lock.json
@@ -81,9 +81,7 @@
     "yoda": "off",
     "no-param-reassign": "off",
     // End of new rules added by updating package-lock.json
-    "max-len": ["error", {
-      "code": 120
-    }],
+    "@typescript-eslint/camelcase": "off", // duplicates "camelcase" from airbnb
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
     "@typescript-eslint/indent": ["error", 2],
@@ -119,6 +117,7 @@
         "devDependencies": [
           "**/*.test.ts",
           "**/*.test.tsx",
+          "cypress/**",
           "src/store/mockStore.ts",
           "src/setupTests.ts"
         ]
@@ -127,7 +126,9 @@
     "import/no-unresolved": "off",
     "import/order": "off",
     "import/prefer-default-export": "off",
+    "max-len": ["error", {"code": 120}],
     "no-console": "warn",
+    "no-use-before-define": "off",
     "react/destructuring-assignment": "off",
     "react/jsx-filename-extension": ["error", {"extensions": [".tsx"]}],
     "react/prop-types": "off",

--- a/employee-rostering-frontend/cypress/.eslintrc.json
+++ b/employee-rostering-frontend/cypress/.eslintrc.json
@@ -4,5 +4,8 @@
   ],
   "env": {
     "cypress/globals": true
+  },
+  "rules": {
+    "global-require": "off"
   }
 }

--- a/employee-rostering-frontend/cypress/plugins/index.js
+++ b/employee-rostering-frontend/cypress/plugins/index.js
@@ -27,14 +27,11 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-/* eslint-disable global-require */
-/* eslint-disable import/no-extraneous-dependencies */
+// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on('task', {
     failed: require('cypress-failed-log/src/failed')(),
-  })
-}
-/* eslint-enable global-require */
-/* eslint-enable import/no-extraneous-dependencies */
+  });
+};

--- a/employee-rostering-frontend/cypress/support/index.js
+++ b/employee-rostering-frontend/cypress/support/index.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.
@@ -28,8 +28,4 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
-/* eslint-disable global-require */
-/* eslint-disable import/no-extraneous-dependencies */
 require('cypress-failed-log');
-/* eslint-enable global-require */
-/* eslint-enable import/no-extraneous-dependencies */

--- a/employee-rostering-frontend/src/i18n.ts
+++ b/employee-rostering-frontend/src/i18n.ts
@@ -29,8 +29,9 @@ function languageToMomentLocale(lang: string): string {
   switch (lang) {
     case 'cmn':
       return 'zh-cn';
+    default:
+      return lang;
   }
-  return lang;
 }
 
 // From https://github.com/i18next/react-i18next/blob/master/example/react/src/i18n.js

--- a/employee-rostering-frontend/src/store/availability/operations.ts
+++ b/employee-rostering-frontend/src/store/availability/operations.ts
@@ -49,7 +49,7 @@ export const addEmployeeAvailability: ThunkCommandFactory<EmployeeAvailability, 
   (dispatch, state, client) => {
     const tenantId = employeeAvailability.tenantId;
     return client.post<KindaEmployeeAvailabilityView>(`/tenant/${tenantId}/employee/availability/add`,
-      availabilityAdapter(employeeAvailability)).then(newEmployeeAvailability => {
+      availabilityAdapter(employeeAvailability)).then(() => {
       dispatch(refreshShiftRoster());
       dispatch(refreshAvailabilityRoster());
     });
@@ -79,7 +79,7 @@ export const updateEmployeeAvailability: ThunkCommandFactory<EmployeeAvailabilit
   (dispatch, state, client) => {
     const tenantId = employeeAvailability.tenantId;
     return client.put<KindaEmployeeAvailabilityView>(`/tenant/${tenantId}/employee/availability/update`,
-      availabilityAdapter(employeeAvailability)).then(updatedAvailability => {
+      availabilityAdapter(employeeAvailability)).then(() => {
       dispatch(refreshShiftRoster());
       dispatch(refreshAvailabilityRoster());
     });

--- a/employee-rostering-frontend/src/store/roster/operations.ts
+++ b/employee-rostering-frontend/src/store/roster/operations.ts
@@ -123,7 +123,7 @@ ThunkCommandFactory<void, TerminateSolvingRosterEarlyAction> = () => (dispatch, 
 };
 
 export const getInitialShiftRoster:
-ThunkCommandFactory<void, ShiftRosterViewAction> = () => (dispatch, state, client) => {
+ThunkCommandFactory<void, ShiftRosterViewAction> = () => (dispatch, state) => {
   const { rosterState } = state().rosterState;
   if (rosterState !== null) {
     const startDate = moment(rosterState.firstDraftDate).startOf('week').toDate();
@@ -146,7 +146,7 @@ ThunkCommandFactory<void, ShiftRosterViewAction> = () => (dispatch, state, clien
 }
 
 export const getInitialAvailabilityRoster:
-ThunkCommandFactory<void, AvailabilityRosterViewAction> = () => (dispatch, state, client) => {
+ThunkCommandFactory<void, AvailabilityRosterViewAction> = () => (dispatch, state) => {
   const { rosterState } = state().rosterState;
   if (rosterState !== null) {
     const startDate = moment(rosterState.firstDraftDate).startOf('week').toDate();
@@ -170,7 +170,7 @@ ThunkCommandFactory<void, AvailabilityRosterViewAction> = () => (dispatch, state
 
 export const refreshShiftRoster:
 ThunkCommandFactory<void, SetShiftRosterIsLoadingAction |
-SetShiftRosterViewAction> = () => (dispatch, state, client) => {
+SetShiftRosterViewAction> = () => (dispatch) => {
   if (lastCalledShiftRosterArgs !== null && lastCalledShiftRoster !== null) {
     dispatch(lastCalledShiftRoster(lastCalledShiftRosterArgs));
   }
@@ -178,7 +178,7 @@ SetShiftRosterViewAction> = () => (dispatch, state, client) => {
 
 export const refreshAvailabilityRoster:
 ThunkCommandFactory<void, SetAvailabilityRosterIsLoadingAction |
-SetAvailabilityRosterViewAction> = () => (dispatch, state, client) => {
+SetAvailabilityRosterViewAction> = () => (dispatch) => {
   if (lastCalledAvailabilityRosterArgs !== null && lastCalledAvailabilityRoster !== null) {
     dispatch(lastCalledAvailabilityRoster(lastCalledAvailabilityRosterArgs));
   }

--- a/employee-rostering-frontend/src/store/roster/roster.test.ts
+++ b/employee-rostering-frontend/src/store/roster/roster.test.ts
@@ -248,6 +248,8 @@ describe('Roster operations', () => {
           onPost(restURL, restArg, { ...mockShiftRoster, spotIdToShiftViewListMap: {}, score: "0hard/0medium/0soft" });
           break;
         }
+
+        default: throw new Error();
       }
 
       await operation();
@@ -275,6 +277,8 @@ describe('Roster operations', () => {
           expect(client.post).toHaveBeenNthCalledWith(2, restURL, restArg);
           break;
         }
+
+        default: throw new Error();
       }
     };
 
@@ -344,6 +348,8 @@ describe('Roster operations', () => {
           });
           break;
         }
+
+        default: throw new Error();
       }
 
       await operation();
@@ -374,6 +380,8 @@ describe('Roster operations', () => {
           expect(client.post).toHaveBeenNthCalledWith(2, restURL, restArg);
           break;
         }
+
+        default: throw new Error();
       }
     };
 

--- a/employee-rostering-frontend/src/store/shift/KindaShiftView.ts
+++ b/employee-rostering-frontend/src/store/shift/KindaShiftView.ts
@@ -42,12 +42,12 @@ export function kindaShiftViewAdapter(kindaShiftView: KindaShiftView): ShiftView
   
   // Since property P is related to indictments iff it is an array,
   // We can convert all indictments by mapping all keys that are arrays
-  for(const key in kindaShiftViewClone) {
+  Object.keys(kindaShiftViewClone).forEach(key => {
     if (Array.isArray(kindaShiftViewClone[key])) {
       kindaShiftViewClone[key] = kindaShiftViewClone[key].map((s: any) => 
         ({ ...s, score: getHardMediumSoftScoreFromString(s.score) }));
     }
-  }
+  });
 
   return {
     ...kindaShiftViewClone,

--- a/employee-rostering-frontend/src/store/shift/operations.ts
+++ b/employee-rostering-frontend/src/store/shift/operations.ts
@@ -24,7 +24,7 @@ import { refreshShiftRoster, refreshAvailabilityRoster } from 'store/roster/oper
 export const addShift: ThunkCommandFactory<Shift, any> = shift =>
   (dispatch, state, client) => {
     const tenantId = shift.tenantId;
-    return client.post<KindaShiftView>(`/tenant/${tenantId}/shift/add`, shiftAdapter(shift)).then(newShift => {
+    return client.post<KindaShiftView>(`/tenant/${tenantId}/shift/add`, shiftAdapter(shift)).then(() => {
       dispatch(refreshShiftRoster());
       dispatch(refreshAvailabilityRoster());
     });
@@ -51,7 +51,7 @@ export const removeShift: ThunkCommandFactory<Shift, any> = shift =>
 export const updateShift: ThunkCommandFactory<Shift, any> = shift =>
   (dispatch, state, client) => {
     const tenantId = shift.tenantId;
-    return client.put<KindaShiftView>(`/tenant/${tenantId}/shift/update`, shiftAdapter(shift)).then(updatedShift => {
+    return client.put<KindaShiftView>(`/tenant/${tenantId}/shift/update`, shiftAdapter(shift)).then(() => {
       dispatch(refreshShiftRoster());
       dispatch(refreshAvailabilityRoster());
     });

--- a/employee-rostering-frontend/src/store/tenant/operations.ts
+++ b/employee-rostering-frontend/src/store/tenant/operations.ts
@@ -15,7 +15,7 @@
  */
 
 import Tenant from 'domain/Tenant';
-import { ThunkCommandFactory, AppState } from '../types';
+import { ThunkCommandFactory } from '../types';
 import * as actions from './actions';
 import {
   ChangeTenantAction, RefreshTenantListAction, RefreshSupportedTimezoneListAction,
@@ -39,7 +39,7 @@ import { alert } from 'store/alert';
 import RosterState from 'domain/RosterState';
 import { AddAlertAction } from 'store/alert/types';
 
-function refreshData(dispatch: ThunkDispatch<any, any, Action<any>>, state: () => AppState): Promise<any> {
+function refreshData(dispatch: ThunkDispatch<any, any, Action<any>>): Promise<any> {
   dispatch(rosterActions.setShiftRosterIsLoading(true));
   dispatch(rosterActions.setAvailabilityRosterIsLoading(true));
   dispatch(rosterActions.setRosterStateIsLoading(true));
@@ -61,9 +61,9 @@ function refreshData(dispatch: ThunkDispatch<any, any, Action<any>>, state: () =
   });
 }
 
-export const changeTenant: ThunkCommandFactory<number, ChangeTenantAction> = tenantId => (dispatch, state, client) => {
+export const changeTenant: ThunkCommandFactory<number, ChangeTenantAction> = tenantId => (dispatch) => {
   dispatch(actions.changeTenant(tenantId));
-  return refreshData(dispatch, state);
+  return refreshData(dispatch);
 };
 
 export const refreshTenantList:
@@ -78,7 +78,7 @@ ThunkCommandFactory<void, RefreshTenantListAction> = () => (dispatch, state, cli
       // TODO: this case occurs iff there are no tenants; need a special screen for that
       dispatch(actions.refreshTenantList({ tenantList, currentTenantId: 0 }));
     }
-    refreshData(dispatch, state);
+    refreshData(dispatch);
   }));
 
 export const addTenant:

--- a/employee-rostering-frontend/src/ui/Alerts.tsx
+++ b/employee-rostering-frontend/src/ui/Alerts.tsx
@@ -45,10 +45,8 @@ const mapDispatchToProps: DispatchProps = {
 export type Props = StateProps & DispatchProps;
 
 export function mapToComponent(component: AlertComponent, componentProps: BasicObject): React.ReactNode {
-  switch (component) {
-    case AlertComponent.SERVER_SIDE_EXCEPTION_DIALOG: {
-      return <ServerSideExceptionDialog {...componentProps as unknown as ServerSideExceptionInfo} />
-    }
+  if (component === AlertComponent.SERVER_SIDE_EXCEPTION_DIALOG) {
+    return <ServerSideExceptionDialog {...componentProps as unknown as ServerSideExceptionInfo} />;
   }
 }
 

--- a/employee-rostering-frontend/src/ui/components/Background.tsx
+++ b/employee-rostering-frontend/src/ui/components/Background.tsx
@@ -16,25 +16,22 @@
 
 import { BackgroundImage, BackgroundImageSrc } from '@patternfly/react-core';
 import filter from '@patternfly/react-core/dist/styles/assets/images/background-filter.svg';
-
-/* eslint-disable @typescript-eslint/camelcase */
+/* eslint-disable camelcase */
 import pfbg_1200 from '@patternfly/react-core/dist/styles/assets/images/pfbg_1200.jpg';
 import pfbg_576 from '@patternfly/react-core/dist/styles/assets/images/pfbg_576.jpg';
 import pfbg_576_2x from '@patternfly/react-core/dist/styles/assets/images/pfbg_576@2x.jpg';
 import pfbg_768 from '@patternfly/react-core/dist/styles/assets/images/pfbg_768.jpg';
 import pfbg_768_2x from '@patternfly/react-core/dist/styles/assets/images/pfbg_768@2x.jpg';
 import * as React from 'react';
-/* eslint-enable @typescript-eslint/camelcase */
+/* eslint-enable camelcase */
 
 const bgImages = {
-  /* eslint-disable @typescript-eslint/camelcase */
   [BackgroundImageSrc.lg]: pfbg_1200,
   [BackgroundImageSrc.sm]: pfbg_768,
   [BackgroundImageSrc.sm2x]: pfbg_768_2x,
   [BackgroundImageSrc.xs]: pfbg_576,
   [BackgroundImageSrc.xs2x]: pfbg_576_2x,
-  [BackgroundImageSrc.filter]: `${filter}#image_overlay`
-  /* eslint-enable @typescript-eslint/camelcase */
+  [BackgroundImageSrc.filter]: `${filter}#image_overlay`,
 };
 
 const Background: React.FC = () => (

--- a/employee-rostering-frontend/src/ui/components/DataTable.test.tsx
+++ b/employee-rostering-frontend/src/ui/components/DataTable.test.tsx
@@ -26,12 +26,12 @@ class MockDataTable extends DataTable<MockData, DataTableProps<MockData>> {
   displayDataRow = jest.fn((data) => [<span key={0} id="viewer">{data.name}</span>,
     <span key={1}>{data.number}</span>]);
   getInitialStateForNewRow = jest.fn(() => ({}));
-  editDataRow = jest.fn((data) => [<input key={0} id="editor" />,
+  editDataRow = jest.fn(() => [<input key={0} id="editor" />,
     <input key={1} />]);
   isValid = jest.fn();
   isDataComplete = jest.fn() as any;
   getSorters = jest.fn(() => [null, stringSorter((d: MockData) => String(d.number))]);
-  getFilter = jest.fn((() => (filter: string) => (t: MockData) => Boolean(true)));
+  getFilter = jest.fn((() => () => () => Boolean(true)));
 
   updateData = jest.fn();
   addData = jest.fn();

--- a/employee-rostering-frontend/src/ui/components/DataTable.tsx
+++ b/employee-rostering-frontend/src/ui/components/DataTable.tsx
@@ -64,7 +64,7 @@ export abstract class DataTable<T, P extends DataTableProps<T>> extends React.Co
     this.state = {
       editedRows: [],
       newRowData: null,
-      currentFilter: t => true,
+      currentFilter: () => true,
       page: 1,
       perPage: 10,
       sortBy: {},

--- a/employee-rostering-frontend/src/ui/components/MultiTypeaheadSelectInput.test.tsx
+++ b/employee-rostering-frontend/src/ui/components/MultiTypeaheadSelectInput.test.tsx
@@ -48,7 +48,7 @@ describe('MultiTypeaheadSelectInput component', () => {
     const defaultValue = [{name: "Option 2"}];
     const select = mount(<MultiTypeaheadSelectInput {...selectProps} value={defaultValue} />);
     const event: any = {};
-    (select.instance() as Select).onSelect(event, "Option 2", false);
+    (select.instance() as Select).onSelect(event, "Option 2");
     expect(selectProps.onChange).toBeCalled();
     expect(selectProps.onChange).toBeCalledWith([]);
   });
@@ -66,7 +66,7 @@ describe('MultiTypeaheadSelectInput component', () => {
     const defaultValue = [{name: "Option 2"}];
     const select = mount(<MultiTypeaheadSelectInput {...selectProps} value={defaultValue} />);
     const event: any = {};
-    (select.instance() as Select).onSelect(event, "Option 1", false);
+    (select.instance() as Select).onSelect(event, "Option 1");
     expect(selectProps.onChange).toBeCalled();
     expect(selectProps.onChange).toBeCalledWith([...defaultValue, {name: "Option 1"}]);
   });

--- a/employee-rostering-frontend/src/ui/components/MultiTypeaheadSelectInput.tsx
+++ b/employee-rostering-frontend/src/ui/components/MultiTypeaheadSelectInput.tsx
@@ -79,7 +79,7 @@ MultiTypeaheadSelectState>  {
     });
   }
 
-  onSelect(event: any, selection: string, isPlaceholder: boolean) {
+  onSelect(event: any, selection: string) {
     const selected = this.props.value;
     const selectedOption = this.props.options.find((option) => this.props.optionToStringMap(option) === selection) as T;
     if (selected.map(this.props.optionToStringMap).includes(selection)) {

--- a/employee-rostering-frontend/src/ui/components/TypeaheadSelectInput.test.tsx
+++ b/employee-rostering-frontend/src/ui/components/TypeaheadSelectInput.test.tsx
@@ -50,7 +50,7 @@ describe('TypeaheadSelectInput component', () => {
     const select = mount(<TypeaheadSelectInput {...selectProps} value={defaultValue} />);
     const event: any = {};
     select.setState({ isExpanded: true });
-    (select.instance() as Select).onSelect(event, "Option 1", false);
+    (select.instance() as Select).onSelect(event, "Option 1");
     jest.runOnlyPendingTimers();
     expect(select.state("isExpanded")).toEqual(false);
     expect(selectProps.onChange).toBeCalled();

--- a/employee-rostering-frontend/src/ui/components/TypeaheadSelectInput.tsx
+++ b/employee-rostering-frontend/src/ui/components/TypeaheadSelectInput.tsx
@@ -91,8 +91,7 @@ TypeaheadSelectState
   }
 
   onSelect(event: any,
-    selection: string,
-    isPlaceholder: boolean) {
+    selection: string) {
     const selectedOption = this.props.options.find(
       option => this.props.optionToStringMap(option) === selection
     ) as T;

--- a/employee-rostering-frontend/src/ui/header/Toolbar.tsx
+++ b/employee-rostering-frontend/src/ui/header/Toolbar.tsx
@@ -133,7 +133,7 @@ export class ToolbarComponent extends React.Component<Props, ToolbarState> {
                     {currentTenant.name}
                   </DropdownToggle>
                 )}
-                dropdownItems={tenantList.map((tenant, index) => {
+                dropdownItems={tenantList.map((tenant) => {
                   return <DropdownItem data-tenantid={tenant.id} key={tenant.id}>{tenant.name}</DropdownItem>;
                 })}
               />

--- a/employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.test.tsx
+++ b/employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.test.tsx
@@ -332,7 +332,7 @@ describe('Availability Roster Page', () => {
     });
   });
 
-  it('should color desired availablities green', () => {
+  it('should color desired availabilities green', () => {
     const availabilityRosterPage = new AvailabilityRosterPage(baseProps);
 
     const draftAvailability: ShiftOrAvailability = {
@@ -354,7 +354,7 @@ describe('Availability Roster Page', () => {
     });
   });
 
-  it('should color undesired availablities yellow', () => {
+  it('should color undesired availabilities yellow', () => {
     const availabilityRosterPage = new AvailabilityRosterPage(baseProps);
 
     const draftAvailability: ShiftOrAvailability = {
@@ -376,7 +376,7 @@ describe('Availability Roster Page', () => {
     });
   });
 
-  it('should color unavailable availablities red', () => {
+  it('should color unavailable availabilities red', () => {
     const availabilityRosterPage = new AvailabilityRosterPage(baseProps);
 
     const draftAvailability: ShiftOrAvailability = {
@@ -396,6 +396,19 @@ describe('Availability Roster Page', () => {
         border: "1px dashed"
       }
     });
+  });
+
+  it('getEventStyle() should throw error on wrong state', () => {
+    const draftAvailability: ShiftOrAvailability = {
+      type: 'Availability',
+      start: availability.startDateTime,
+      end: availability.endDateTime,
+      reference: {
+        ...availability,
+        state: 'wrong state' as 'DESIRED',
+      },
+    };
+    expect(() => new AvailabilityRosterPage(baseProps).getEventStyle(draftAvailability)).toThrow(Error);
   });
 
   it('day should be white if it is draft and no availabilities falls on the day', () => {
@@ -465,6 +478,13 @@ describe('Availability Roster Page', () => {
       style: {
       }
     });
+  });
+
+  it('getDayStyle() should throw error on wrong state', () => {
+    expect(() => new AvailabilityRosterPage(baseProps).getDayStyle([{
+      ...availability,
+      state: "wrong state" as "DESIRED"
+    }])(availability.startDateTime)).toThrow(Error);
   });
 
   // isDay

--- a/employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
+++ b/employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.tsx
@@ -205,6 +205,8 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
           style.backgroundColor = 'red';
           break;
         }
+        default:
+          throw new Error(`Unexpected availability state: ${soa.reference.state}`);
       }
     }
 
@@ -237,6 +239,8 @@ export class AvailabilityRosterPage extends React.Component<Props, State> {
             className = "unavailable";
             break;
           }
+          default:
+            throw new Error(`Unexpected availability state: ${dayAvailability.state}`);
         }
       }
       if (this.props.rosterState !== null && moment(date).isBefore(this.props.rosterState.firstDraftDate)) {

--- a/employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.tsx
+++ b/employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.tsx
@@ -148,13 +148,13 @@ export const ShiftEmployeeConflictViolations: React.FC<Shift> = (shift) => {
       ))}
     </>
   );
-} 
+}
 
 export const RotationViolationPenalties: React.FC<Shift> = (shift) => {
   const { t } = useTranslation("ShiftEvent");
   return (
     <>
-      {(shift.rotationViolationPenaltyList || []).map((v, index) => (
+      {(shift.rotationViolationPenaltyList || []).map((v) => (
         <li key={v.shift.id}>
           {t("employeeDoesNotMatchRotationEmployee", {
             employee: (v.shift.employee as Employee).name,
@@ -172,7 +172,7 @@ export const UnassignedShiftPenalties: React.FC<Shift> = (shift) => {
   const { t } = useTranslation("ShiftEvent");
   return (
     <>
-      {(shift.unassignedShiftPenaltyList || []).map((v, index) => (
+      {(shift.unassignedShiftPenaltyList || []).map((v) => (
         <li key={v.shift.id}>
           {t("unassignedShift")}
           <br />

--- a/employee-rostering-frontend/src/util/ImmutableCollectionOperations.ts
+++ b/employee-rostering-frontend/src/util/ImmutableCollectionOperations.ts
@@ -57,7 +57,7 @@ export function objectWithout<F>(obj: F, ...without: (keyof F)[]): F {
 export function mapDomainObjectToView<T extends DomainObject>(obj: T|DomainObjectView<T>): DomainObjectView<T> {
   let result = {} as ObjectWithKeys;
   const objWithKeys = obj as ObjectWithKeys;
-  for(const key in obj) {
+  Object.keys(objWithKeys).forEach(key => {
     if (objWithKeys[key] !== null && objWithKeys[key].id !== undefined) {
       result[key] = objWithKeys[key].id;
     }
@@ -67,7 +67,7 @@ export function mapDomainObjectToView<T extends DomainObject>(obj: T|DomainObjec
     else {
       result[key] = objWithKeys[key];
     }
-  }
+  });
   return result as DomainObjectView<T>;
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/PLANNER-1732

For code style and project configuration consistency it is important to unify `.eslintrc.json` between Vehicle Routing and Employee Rostering.

Some time ago I have introduced the airbnb ESLint config (#251) but I've given it a low priority to avoid introducing big changes. Now's the time to take a step further and give it the top priority.

In the next step I'd like to eliminate most of the exceptions to the style (disabled rules).
