### PR TITLE
Remove Springfox dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,17 +121,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <dependency>
-        <groupId>io.springfox</groupId>
-        <artifactId>springfox-swagger2</artifactId>
-        <version>2.9.2</version>
-      </dependency>
-      <dependency>
-        <groupId>io.springfox</groupId>
-        <artifactId>springfox-swagger-ui</artifactId>
-        <version>2.9.2</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1129.