### PR TITLE
Fix README build command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ Build the project with maven in the project's root directory:
 
 [source,shell]
 ----
-mvn clean install -DskipTests -DskipITs
+mvn clean install -DskipTests -DskipITs -Denforcer.skip=true
 ----
 
 == Running


### PR DESCRIPTION
Provides a workaround in the README docs to prevent users encountering a broken build in the first command instruction.

Reason: Running `mvn clean install -DskipTests -DskipITs` in the project directory results in the build breaking with this message: 

`
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequirePluginVersions failed with message:
Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed )
com.github.eirslett:frontend-maven-plugin. The version currently in use is 1.8.0
`

This is probably caused by removing the frontend-maven-plugin version override in this [commit](https://github.com/kiegroup/optaweb-employee-rostering/commit/c0d0b8648bf6e5ce326cd08664664be549e091f7). 