### PR TITLE
Update node version to v11.6.0

### DIFF
--- a/employee-rostering-frontend/pom.xml
+++ b/employee-rostering-frontend/pom.xml
@@ -30,7 +30,7 @@
   <description>React frontend for Employee Rostering as a Service</description>
 
   <properties>
-    <node.version>v8.12.0</node.version>
+    <node.version>v11.6.0</node.version>
     <npm.version>6.9.0</npm.version>
   </properties>
 
@@ -68,7 +68,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>run locktt -- </arguments>
+              <arguments>run locktt --</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This is needed for the w2k16 Jenkins jobs to build; the older repository doesn't contain win-x64/node.exe.