### PR TITLE
RHPAM-2609: Update node version to v11.6.0 (#354)

### DIFF
--- a/employee-rostering-frontend/pom.xml
+++ b/employee-rostering-frontend/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <frontend-maven-plugin.version>1.7.5</frontend-maven-plugin.version>
-    <node.version>v8.12.0</node.version>
+    <node.version>v11.6.0</node.version>
     <npm.version>6.9.0</npm.version>
   </properties>
 


### PR DESCRIPTION
This is needed for the w2k16 Jenkins jobs to build; the older repository doesn't contain win-x64/node.exe.

(cherry picked from commit 43af609765500f7abe8b86f7f7f0e8279f754b51)