### PR TITLE
[7.30.x] Add locktt script to package.json

### DIFF
--- a/employee-rostering-frontend/package.json
+++ b/employee-rostering-frontend/package.json
@@ -46,7 +46,8 @@
     "lint": "eslint --ext .js,.ts,.tsx src/ cypress/",
     "lint:fix": "npm run lint -- --fix",
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:run": "cypress run",
+    "locktt": "locktt"
   },
   "jest-junit": {
     "outputDirectory": "./target/surefire-reports",


### PR DESCRIPTION
I noticed production integration tests are failing due to a missing script in package.json that is referenced from the productized profile. This PR simply adds the missing script.