### PR TITLE
backend: allow postgres host to be specified

### DIFF
--- a/employee-rostering-backend/src/main/resources/application.properties
+++ b/employee-rostering-backend/src/main/resources/application.properties
@@ -5,7 +5,7 @@ logging.level.org.drools=INFO
 logging.level.org.optaplanner.core=INFO
 
 # Datasource
-spring.datasource.url=jdbc:postgresql://postgresql:5432/${DATABASE_NAME}
+spring.datasource.url=jdbc:postgresql://${DATABASE_HOST:postgresql}:5432/${DATABASE_NAME}
 spring.datasource.username=${DATABASE_USER}
 spring.datasource.password=${DATABASE_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
The Spring `application.properties` file in the backend assumes that deployments will only be to a cluster of docker containers. Allow the env var `DATABASE_HOST` to be injected into `spring.datasource.url` to give some flexibility for production deployments involving a postgres database