### PR TITLE
Replace module-relative paths in sonar inclusion with project-relative

### DIFF
--- a/optaweb-employee-rostering-frontend/pom.xml
+++ b/optaweb-employee-rostering-frontend/pom.xml
@@ -34,7 +34,6 @@
     <node.version>v11.6.0</node.version>
     <npm.version>6.9.0</npm.version>
     <sonar.sources>src</sonar.sources>
-    <sonar.test.inclusions>**/*test.ts,**/*test.tsx</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths>coverage/lcov.info</sonar.javascript.lcov.reportPaths>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
     <jacoco.agent.argLine/>
     <sonar.projectKey>optaweb-employee-rostering</sonar.projectKey>
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+    <sonar.test.inclusions>
+      optaweb-employee-rostering-frontend/**/*test.ts,
+      optaweb-employee-rostering-frontend/**/*test.tsx
+    </sonar.test.inclusions>
     <version.org.mockito>2.12.0</version.org.mockito>
     <version.org.postgresql>42.2.6</version.org.postgresql>
   </properties>


### PR DESCRIPTION
Removes following warning:

Specifying module-relative paths at project level in the property
'sonar.exclusions' is deprecated. To continue matching files like
'employee-rostering-frontend/src/store/alert/alert.test.ts', update
this property so that patterns refer to project-relative paths.