### PR TITLE
e2e tests: Double waiting period for launch to 60s

### DIFF
--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -137,6 +137,7 @@
                 <configuration>
                   <name>Run application</name>
                   <healthcheckUrl>http://localhost:${application.port}</healthcheckUrl>
+                  <waitAfterLaunch>60</waitAfterLaunch>
                   <workingDir>${project.build.directory}</workingDir>
                   <processLogFile>${project.build.directory}/${project.artifactId}.log</processLogFile>
                   <arguments>


### PR DESCRIPTION
We are starting to experience timeouts in e2e tests while waiting for standalone to launch. The proposed change doubles the number of seconds to wait for the launch from 30 to 60