### PR TITLE
Allow copying of shifts

### DIFF
--- a/optaweb-employee-rostering-frontend/src/ui/pages/rotation/RotationPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/rotation/RotationPage.tsx
@@ -32,7 +32,7 @@ import { RosterState } from 'domain/RosterState';
 import { ShiftTemplate } from 'domain/ShiftTemplate';
 import { shiftTemplateSelectors, shiftTemplateOperations } from 'store/rotation';
 import { WithTranslation, withTranslation, useTranslation, Trans } from 'react-i18next';
-import { EditIcon, TrashIcon, CubesIcon } from '@patternfly/react-icons';
+import { EditIcon, TrashIcon, CubesIcon, BlueprintIcon } from '@patternfly/react-icons';
 import Schedule from 'ui/components/calendar/Schedule';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { UrlProps, getPropsFromUrl, setPropsInUrl } from 'util/BookmarkableUtils';
@@ -95,6 +95,7 @@ const ShiftTemplatePopoverHeader: React.FC<{
   shiftTemplate: ShiftTemplate;
   rotationLength: number;
   onEdit: (shift: ShiftTemplate) => void;
+  onCopy: (shift: ShiftTemplate) => void;
   onDelete: (shift: ShiftTemplate) => void;
 }> = (props) => {
   const { t } = useTranslation('RotationPage');
@@ -126,6 +127,12 @@ const ShiftTemplatePopoverHeader: React.FC<{
         variant={ButtonVariant.link}
       >
         <EditIcon />
+      </Button>
+      <Button
+        onClick={() => props.onCopy(props.shiftTemplate)}
+        variant={ButtonVariant.link}
+      >
+        <BlueprintIcon />
       </Button>
       <Button
         onClick={() => props.onDelete(props.shiftTemplate)}
@@ -375,6 +382,12 @@ export class RotationPage extends React.Component<Props & WithTranslation, State
             onEdit: shiftTemplate => this.setState({
               selectedShiftTemplate: shiftTemplate,
               isCreatingOrEditingShiftTemplate: true,
+            }),
+            onCopy: shiftTemplate => this.props.addShiftTemplate({
+              ...shiftTemplate,
+              rotationEmployee: null,
+              id: undefined,
+              version: undefined,
             }),
             onDelete: shiftTemplate => this.props.removeShiftTemplate(shiftTemplate),
           })

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.test.tsx
@@ -222,7 +222,7 @@ describe('ShiftEvent', () => {
 
   it('should render ShiftPopupHeader correctly', () => {
     const shiftEventObj = shallow(
-      <Indictments.ShiftPopupHeader shift={baseShift} onEdit={jest.fn()} onDelete={jest.fn()} />,
+      <Indictments.ShiftPopupHeader shift={baseShift} onEdit={jest.fn()} onCopy={jest.fn()} onDelete={jest.fn()} />,
     );
     expect(toJson(shiftEventObj)).toMatchSnapshot();
   });

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.tsx
@@ -20,7 +20,7 @@ import { Text, Button, ButtonVariant, List } from '@patternfly/react-core';
 import moment from 'moment';
 import { Employee } from 'domain/Employee';
 import { convertHardMediumSoftScoreToString } from 'domain/HardMediumSoftScore';
-import { EditIcon, TrashIcon, ThumbTackIcon } from '@patternfly/react-icons';
+import { BlueprintIcon, EditIcon, TrashIcon, ThumbTackIcon } from '@patternfly/react-icons';
 import Color from 'color';
 import { useTranslation } from 'react-i18next';
 
@@ -257,6 +257,7 @@ export function getShiftColor(shift: Shift): string {
 const ShiftPopupHeader: React.FC<{
   shift: Shift;
   onEdit: (shift: Shift) => void;
+  onCopy?: (shift: Shift) => void;
   onDelete: (shift: Shift) => void;
 }> = (props) => {
   const { t } = useTranslation('ShiftEvent');
@@ -276,6 +277,18 @@ const ShiftPopupHeader: React.FC<{
       >
         <EditIcon />
       </Button>
+      {
+        props.onCopy
+          ? (
+            <Button
+              onClick={() => props.onCopy && props.onCopy(props.shift)}
+              variant={ButtonVariant.link}
+            >
+              <BlueprintIcon />
+            </Button>
+          )
+          : null
+      }
       <Button
         onClick={() => props.onDelete(props.shift)}
         variant={ButtonVariant.link}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
@@ -360,6 +360,12 @@ export class ShiftRosterPage extends React.Component<Props, State> {
               isCreatingOrEditingShift: true,
               selectedShift: editedShift,
             }),
+            onCopy: copiedShift => this.addShift({
+              ...copiedShift,
+              employee: null,
+              id: undefined,
+              version: undefined,
+            }),
             onDelete: deletedShift => this.deleteShift(deletedShift),
           })}
           popoverBody={shift => ShiftPopupBody(shift)}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftEvent.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftEvent.test.tsx.snap
@@ -5537,6 +5537,17 @@ exports[`ShiftEvent should render ShiftPopupHeader correctly 1`] = `
     onClick={[Function]}
     variant="link"
   >
+    <BlueprintIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  </Component>
+  <Component
+    onClick={[Function]}
+    variant="link"
+  >
     <TrashIcon
       color="currentColor"
       noVerticalAlign={false}


### PR DESCRIPTION

<img width="466" alt="Screenshot 2020-02-18 at 11 17 46 AM" src="https://user-images.githubusercontent.com/10572368/74703004-d1d7f180-5246-11ea-82f3-6bc6301c4590.png">

It is somewhat common to have multiple people scheduled within the same
time period of a roster, so introduce a button in ShiftPopupHeader (and
template equivalent) that allows the quick copying of shifts

- Popup headers: Create a button that invokes an `onCopy()` callback
  - make this optional for ShiftPopupHeader usage in
    AvailabilityRosterPage as it makes little sense in the user-level
    view to copy a slot with either the same user or nobody assigned
    (the latter because the copied slot then disappears from view)
- Implement callbacks for RotationPage and ShiftRosterPage