### PR TITLE
Add missing test coverage for edit/delete/copy button on events in rosters

### DIFF
--- a/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/availability/AvailabilityRosterPage.test.tsx
@@ -27,6 +27,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import Actions from 'ui/components/Actions';
 import { getRouterProps } from 'util/BookmarkableTestUtils';
 import Schedule from 'ui/components/calendar/Schedule';
+import { EditIcon, TrashIcon } from '@patternfly/react-icons';
 import {
   AvailabilityRosterPage, Props, ShiftOrAvailability, isShift, isAvailability,
   isAllDayAvailability, isDay, AvailabilityRosterUrlProps,
@@ -521,6 +522,71 @@ describe('Availability Roster Page', () => {
     expect(isDay(moment('2018-07-01T00:00').toDate(), moment('2018-07-02T09:00').toDate())).toEqual(false);
     expect(isDay(moment('2018-07-01T00:00').toDate(), moment('2018-07-02T00:00').toDate())).toEqual(true);
     expect(isDay(moment('2018-07-01T00:00').toDate(), moment('2018-07-04T00:00').toDate())).toEqual(true);
+  });
+
+  it('should bring up the Edit Shift modal when the edit button is clicked on a shift', () => {
+    const availabilityRosterPage = shallow(<AvailabilityRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<ShiftOrAvailability> = availabilityRosterPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{
+      type: 'Shift',
+      reference: shift,
+      start: shift.startDateTime,
+      end: shift.endDateTime,
+    }}
+    />);
+    popoverHeader.find(EditIcon).parent().simulate('click');
+    expect(availabilityRosterPage.state('isCreatingOrEditingShift')).toEqual(true);
+    expect(availabilityRosterPage.state('selectedShift')).toEqual(shift);
+  });
+
+  it('should delete the shift when the delete button is clicked on a shift', () => {
+    const availabilityRosterPage = shallow(<AvailabilityRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<ShiftOrAvailability> = availabilityRosterPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{
+      type: 'Shift',
+      reference: shift,
+      start: shift.startDateTime,
+      end: shift.endDateTime,
+    }}
+    />);
+    popoverHeader.find(TrashIcon).parent().simulate('click');
+    expect(baseProps.updateShift).toBeCalledWith({
+      ...shift,
+      employee: null,
+    });
+  });
+
+  it('should bring up the Edit Availability modal when the edit button is clicked on a availability', () => {
+    const availabilityRosterPage = shallow(<AvailabilityRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<ShiftOrAvailability> = availabilityRosterPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{
+      type: 'Availability',
+      reference: availability,
+      start: availability.startDateTime,
+      end: availability.endDateTime,
+    }}
+    />);
+    popoverHeader.find(EditIcon).parent().simulate('click');
+    expect(availabilityRosterPage.state('isCreatingOrEditingAvailability')).toEqual(true);
+    expect(availabilityRosterPage.state('selectedAvailability')).toEqual(availability);
+  });
+
+  it('should delete the availability when the delete button is clicked on a availability', () => {
+    const availabilityRosterPage = shallow(<AvailabilityRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<ShiftOrAvailability> = availabilityRosterPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{
+      type: 'Availability',
+      reference: availability,
+      start: availability.startDateTime,
+      end: availability.endDateTime,
+    }}
+    />);
+    popoverHeader.find(TrashIcon).parent().simulate('click');
+    expect(baseProps.removeEmployeeAvailability).toBeCalledWith(availability);
   });
 });
 

--- a/optaweb-employee-rostering-frontend/src/ui/pages/rotation/RotationPage.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/rotation/RotationPage.test.tsx
@@ -25,6 +25,7 @@ import { useTranslation, WithTranslation, Trans } from 'react-i18next';
 import Schedule from 'ui/components/calendar/Schedule';
 import { getRouterProps } from 'util/BookmarkableTestUtils';
 import { Pagination } from '@patternfly/react-core';
+import { BlueprintIcon, EditIcon, TrashIcon } from '@patternfly/react-icons';
 import { RotationPage, Props, RotationPageUrlProps } from './RotationPage';
 
 const baseDate = moment('2018-01-01T00:00').startOf('week').toDate();
@@ -215,6 +216,39 @@ describe('Rotation Page', () => {
       durationBetweenRotationStartAndTemplateStart: moment.duration(168, 'hours'),
       shiftTemplateDuration: moment.duration(8, 'hours'),
     });
+  });
+
+  it('should bring up the Edit Shift Template modal when the edit button is clicked on a shift', () => {
+    const rotationPage = shallow(<RotationPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<{ shiftTemplate: ShiftTemplate}> = rotationPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{ shiftTemplate }} />);
+    popoverHeader.find(EditIcon).parent().simulate('click');
+    expect(rotationPage.state('isCreatingOrEditingShiftTemplate')).toEqual(true);
+    expect(rotationPage.state('selectedShiftTemplate')).toEqual(shiftTemplate);
+  });
+
+  it('should duplicate a shift template when the copy button is clicked on a shift', () => {
+    const rotationPage = shallow(<RotationPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<{ shiftTemplate: ShiftTemplate}> = rotationPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{ shiftTemplate }} />);
+    popoverHeader.find(BlueprintIcon).parent().simulate('click');
+    expect(baseProps.addShiftTemplate).toBeCalledWith({
+      ...shiftTemplate,
+      rotationEmployee: null,
+      id: undefined,
+      version: undefined,
+    });
+  });
+
+  it('should delete the shift template when the delete button is clicked on a shift', () => {
+    const rotationPage = shallow(<RotationPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<{ shiftTemplate: ShiftTemplate}> = rotationPage
+      .find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...{ shiftTemplate }} />);
+    popoverHeader.find(TrashIcon).parent().simulate('click');
+    expect(baseProps.removeShiftTemplate).toBeCalledWith(shiftTemplate);
   });
 });
 

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftEvent.test.tsx
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { shallow, mount } from 'enzyme';
-import toJson from 'enzyme-to-json';
-import * as React from 'react';
-import { Spot } from 'domain/Spot';
 import { Employee } from 'domain/Employee';
-import { Shift } from 'domain/Shift';
 import { EmployeeAvailability } from 'domain/EmployeeAvailability';
+import { Shift } from 'domain/Shift';
+import { Spot } from 'domain/Spot';
+import { mount, shallow } from 'enzyme';
+import { BlueprintIcon, EditIcon, TrashIcon } from '@patternfly/react-icons';
+import toJson from 'enzyme-to-json';
 import moment from 'moment-timezone';
-import ShiftEvent, * as Indictments from './ShiftEvent';
 import 'moment/locale/en-ca';
+import * as React from 'react';
+import ShiftEvent, * as Indictments from './ShiftEvent';
 
 describe('ShiftEvent', () => {
   it('getRequiredSkillViolations should render correctly', () => {
@@ -225,6 +226,40 @@ describe('ShiftEvent', () => {
       <Indictments.ShiftPopupHeader shift={baseShift} onEdit={jest.fn()} onCopy={jest.fn()} onDelete={jest.fn()} />,
     );
     expect(toJson(shiftEventObj)).toMatchSnapshot();
+  });
+
+  it('should render ShiftPopupHeader correctly without an onCopy function', () => {
+    const shiftEventObj = shallow(
+      <Indictments.ShiftPopupHeader shift={baseShift} onEdit={jest.fn()} onDelete={jest.fn()} />,
+    );
+    expect(toJson(shiftEventObj)).toMatchSnapshot();
+  });
+
+  it('ShiftPopupHeader should call onEdit if onEdit button is clicked', () => {
+    const onEdit = jest.fn();
+    const shiftPopupHeaderObj = shallow(
+      <Indictments.ShiftPopupHeader shift={baseShift} onEdit={onEdit} onCopy={jest.fn()} onDelete={jest.fn()} />,
+    );
+    shiftPopupHeaderObj.find(EditIcon).parent().simulate('click');
+    expect(onEdit).toBeCalledWith(baseShift);
+  });
+
+  it('ShiftPopupHeader should call onCopy if onCopy button is clicked', () => {
+    const onCopy = jest.fn();
+    const shiftPopupHeaderObj = shallow(
+      <Indictments.ShiftPopupHeader shift={baseShift} onEdit={jest.fn()} onCopy={onCopy} onDelete={jest.fn()} />,
+    );
+    shiftPopupHeaderObj.find(BlueprintIcon).parent().simulate('click');
+    expect(onCopy).toBeCalledWith(baseShift);
+  });
+
+  it('ShiftPopupHeader should call onDelete if onDelete button is clicked', () => {
+    const onDelete = jest.fn();
+    const shiftPopupHeaderObj = shallow(
+      <Indictments.ShiftPopupHeader shift={baseShift} onEdit={jest.fn()} onCopy={jest.fn()} onDelete={onDelete} />,
+    );
+    shiftPopupHeaderObj.find(TrashIcon).parent().simulate('click');
+    expect(onDelete).toBeCalledWith(baseShift);
   });
 
   it('should render ShiftPopupBody correctly', () => {

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.test.tsx
@@ -24,6 +24,7 @@ import moment from 'moment-timezone';
 import 'moment/locale/en-ca';
 import color from 'color';
 import { useTranslation, Trans } from 'react-i18next';
+import { BlueprintIcon, EditIcon, TrashIcon } from '@patternfly/react-icons';
 import Actions from 'ui/components/Actions';
 import Schedule from 'ui/components/calendar/Schedule';
 import { getRouterProps } from 'util/BookmarkableTestUtils';
@@ -339,6 +340,36 @@ describe('Shift Roster Page', () => {
         backgroundColor: 'var(--pf-global--BackgroundColor--300)',
       },
     });
+  });
+
+  it('should bring up the Edit Shift modal when the edit button is clicked on a shift', () => {
+    const shiftRosterPage = shallow(<ShiftRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<Shift> = shiftRosterPage.find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...shift} />);
+    popoverHeader.find(EditIcon).parent().simulate('click');
+    expect(shiftRosterPage.state('isCreatingOrEditingShift')).toEqual(true);
+    expect(shiftRosterPage.state('selectedShift')).toEqual(shift);
+  });
+
+  it('should duplicate a shift when the copy button is clicked on a shift', () => {
+    const shiftRosterPage = shallow(<ShiftRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<Shift> = shiftRosterPage.find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...shift} />);
+    popoverHeader.find(BlueprintIcon).parent().simulate('click');
+    expect(baseProps.addShift).toBeCalledWith({
+      ...shift,
+      employee: null,
+      id: undefined,
+      version: undefined,
+    });
+  });
+
+  it('should delete the shift when the delete button is clicked on a shift', () => {
+    const shiftRosterPage = shallow(<ShiftRosterPage {...baseProps} />);
+    const PopoverHeaderComponent: React.FC<Shift> = shiftRosterPage.find(Schedule).prop('popoverHeader');
+    const popoverHeader = shallow(<PopoverHeaderComponent {...shift} />);
+    popoverHeader.find(TrashIcon).parent().simulate('click');
+    expect(baseProps.removeShift).toBeCalledWith(shift);
   });
 });
 

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftEvent.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftEvent.test.tsx.snap
@@ -5557,3 +5557,33 @@ exports[`ShiftEvent should render ShiftPopupHeader correctly 1`] = `
   </Component>
 </span>
 `;
+
+exports[`ShiftEvent should render ShiftPopupHeader correctly without an onCopy function 1`] = `
+<span>
+  <Text>
+    Spot, 9:00 AM-5:00 PM: Employee 1
+  </Text>
+  <Component
+    onClick={[Function]}
+    variant="link"
+  >
+    <EditIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  </Component>
+  <Component
+    onClick={[Function]}
+    variant="link"
+  >
+    <TrashIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  </Component>
+</span>
+`;


### PR DESCRIPTION
@LoneRifle this PR adds test coverage for your PR. (Side note: we probably should add `aria-labels` to these buttons so we don't need to select them by their icons).