### PR TITLE
moment: bring in all locales

### DIFF
--- a/optaweb-employee-rostering-frontend/src/i18n.ts
+++ b/optaweb-employee-rostering-frontend/src/i18n.ts
@@ -22,7 +22,7 @@ import cmn from 'date-fns/locale/zh-CN';
 import YAML from 'yaml';
 
 import moment from 'moment';
-import 'moment/locale/zh-cn';
+import 'moment/min/locales.min';
 
 registerLocale('cmn', cmn);
 


### PR DESCRIPTION
Locales influence the first day of the week, amongst other things.
While the US, Canada and Japan start the week on Sunday, many other
places start it on Monday.

To avoid ambiguity, bring all locales into moment. This results in
an inconsistency between moment and date-fns (and react-datepicker),
which we can reasonably bear with for now