### PR TITLE
Fix Sonar code coverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install: mvn de.qaware.maven:go-offline-maven-plugin:1.2.1:resolve-dependencies 
 # do not install to avoid dirtying the cache
 script:
   - mvn install -Prun-code-coverage -Dintegration-tests=true --show-version
-  - mvn generate-resources -Psonarcloud-analysis
+  - mvn sonar:sonar -Psonarcloud-analysis
   # check that git working tree is clean after running npm install via a frontend-maven-plugin
   # the git command returns 1 and fails the build if there are any uncommitted changes
   - git diff HEAD --exit-code

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
                   </excludes>
                 </configuration>
               </execution>
+              <execution>
+                <id>jacoco-generate-report</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
             </executions>
           </plugin>
         </plugins>


### PR DESCRIPTION
`mvn generate-resources -Psonarcloud-analysis` runs an Ant task that
aggregates reports from individual modules but this project doesn't seem
to be configured correctly for code coverage aggregation.

Adding the report goal fixes code coverage analysis for individual
modules because it generates a JaCoCo XML report in each module that can
be understood by Sonar scanner.

Radek will fix report aggregation later.