### PR TITLE
Restore cross-module coverage measurement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install: mvn de.qaware.maven:go-offline-maven-plugin:1.2.1:resolve-dependencies 
 # do not install to avoid dirtying the cache
 script:
   - mvn install -Prun-code-coverage -Dintegration-tests=true --show-version
-  - mvn sonar:sonar -Psonarcloud-analysis
+  - mvn validate -Psonarcloud-analysis
   # check that git working tree is clean after running npm install via a frontend-maven-plugin
   # the git command returns 1 and fails the build if there are any uncommitted changes
   - git diff HEAD --exit-code

--- a/pom.xml
+++ b/pom.xml
@@ -181,17 +181,14 @@
                   <goal>prepare-agent</goal>
                 </goals>
                 <configuration>
+                  <!-- Append coverage data so a single file defined in the kie-parent -->
+                  <append>true</append>
+                  <destFile>${jacoco.exec.file}</destFile>
                   <propertyName>jacoco.agent.argLine</propertyName>
                   <excludes>
                     <exclude>*Lexer</exclude>
                   </excludes>
                 </configuration>
-              </execution>
-              <execution>
-                <id>jacoco-generate-report</id>
-                <goals>
-                  <goal>report</goal>
-                </goals>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
                   <goal>prepare-agent</goal>
                 </goals>
                 <configuration>
-                  <!-- Append coverage data so a single file defined in the kie-parent -->
+                  <!-- Append coverage data to a single file defined in the kie-parent -->
                   <append>true</append>
                   <destFile>${jacoco.exec.file}</destFile>
                   <propertyName>jacoco.agent.argLine</propertyName>


### PR DESCRIPTION
The reporting is done in the sonarcloud-analysis profile in the kie-parent based on a single file every module appends coverage data to.