### PR TITLE
PLANNER-1958: Allow exporting of Shift Roster to Excel

### DIFF
--- a/optaweb-employee-rostering-backend/pom.xml
+++ b/optaweb-employee-rostering-backend/pom.xml
@@ -104,6 +104,16 @@
       <artifactId>springfox-swagger-ui</artifactId>
     </dependency>
 
+    <!-- Excel -->
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi-ooxml</artifactId>
+    </dependency>
+
     <!-- Required for Java 11 -->
     <dependency>
       <groupId>org.jboss.spec.javax.xml.bind</groupId>

--- a/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -128,8 +128,8 @@ public class RosterController {
                                                                     String startDateString,
                                                             @RequestParam(name = "endDate") String endDateString,
                                                             @RequestParam(name = "spotList") String spotListString) {
-        Set<Long> spotIdSet = Arrays.asList(spotListString.split(",")).stream()
-                .map(Long::parseLong).collect(Collectors.toSet());
+        Set<Long> spotIdSet = Arrays.stream(spotListString.split(",")).map(Long::parseLong)
+                .collect(Collectors.toSet());
         List<Spot> spotList = spotRepository.findAllByTenantId(tenantId, PageRequest.of(0, Integer.MAX_VALUE))
                 .stream().filter(s -> spotIdSet.contains(s.getId()))
                 .collect(Collectors.toList());

--- a/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
+++ b/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/roster/RosterController.java
@@ -16,6 +16,7 @@
 
 package org.optaweb.employeerostering.service.roster;
 
+import java.io.IOException;
 import java.util.List;
 
 import javax.validation.Valid;
@@ -30,6 +31,7 @@ import org.optaweb.employeerostering.domain.roster.view.AvailabilityRosterView;
 import org.optaweb.employeerostering.domain.roster.view.ShiftRosterView;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.service.solver.SolverStatus;
+import org.optaweb.employeerostering.util.ShiftRosterXlsxFileIO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
@@ -106,6 +108,24 @@ public class RosterController {
                                                                  @RequestBody @Valid List<Spot> spots) {
         return new ResponseEntity<>(rosterService.getShiftRosterViewFor(tenantId, startDateString, endDateString,
                                                                         spots), HttpStatus.OK);
+    }
+
+    @ApiOperation("Get a shift roster view between two dates for a subset of the spots as an excel file")
+    @GetMapping(value = "/shiftRosterView/excel",
+            produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    public ResponseEntity<byte[]> getShiftRosterViewAsExcel(@PathVariable @Min(0) Integer tenantId,
+                                                            @RequestParam(name = "startDate")
+                                                                    String startDateString,
+                                                            @RequestParam(name = "endDate") String endDateString) {
+        ShiftRosterView shiftRosterView = rosterService.getShiftRosterView(tenantId, null, null,
+                                                                           startDateString, endDateString);
+        try {
+            return new ResponseEntity<>(ShiftRosterXlsxFileIO.getExcelBytesForShiftRoster(shiftRosterView),
+                                        HttpStatus.OK);
+        } catch (IOException e) {
+            return new ResponseEntity<>(new byte[]{},
+                                        HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // ************************************************************************

--- a/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/util/ShiftRosterXlsxFileIO.java
+++ b/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/util/ShiftRosterXlsxFileIO.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaweb.employeerostering.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.optaweb.employeerostering.domain.employee.Employee;
+import org.optaweb.employeerostering.domain.roster.view.ShiftRosterView;
+import org.optaweb.employeerostering.domain.shift.view.ShiftView;
+import org.optaweb.employeerostering.domain.spot.Spot;
+
+public final class ShiftRosterXlsxFileIO {
+
+    public static final DateTimeFormatter DATE_TIME_FORMATTER
+            = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.ENGLISH);
+
+    // Cannot build instances of this, so private empty constructor
+    private ShiftRosterXlsxFileIO() {
+    }
+
+    public static byte[] getExcelBytesForShiftRoster(ShiftRosterView shiftRosterView) throws IOException {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Map<Long, String> employeeIdToNameMap = shiftRosterView.getEmployeeList().stream()
+                    .collect(Collectors.toMap(Employee::getId, Employee::getName));
+            for (Spot spot : shiftRosterView.getSpotList()) {
+                Sheet sheet = workbook.createSheet(spot.getName());
+                Row headerRow = sheet.createRow(0);
+                Cell headerCell = headerRow.createCell(0);
+                headerCell.setCellValue("Start");
+
+                headerCell = headerRow.createCell(1);
+                headerCell.setCellValue("End");
+
+                headerCell = headerRow.createCell(2);
+                headerCell.setCellValue("Employee");
+
+                int rowNumber = 1;
+                LocalDateTime lastShiftStartDateTime = null;
+                LocalDateTime lastShiftEndDateTime = null;
+                for (ShiftView shift : shiftRosterView.getSpotIdToShiftViewListMap().get(spot.getId())) {
+                    Row shiftRow = sheet.createRow(rowNumber);
+                    if (!shift.getStartDateTime().equals(lastShiftStartDateTime) ||
+                            !shift.getEndDateTime().equals(lastShiftEndDateTime)) {
+                        Cell dateCell = shiftRow.createCell(0);
+                        dateCell.setCellValue(DATE_TIME_FORMATTER.format(shift.getStartDateTime()));
+
+                        dateCell = shiftRow.createCell(1);
+                        dateCell.setCellValue(DATE_TIME_FORMATTER.format(shift.getEndDateTime()));
+
+                        lastShiftStartDateTime = shift.getStartDateTime();
+                        lastShiftEndDateTime = shift.getEndDateTime();
+                        rowNumber++;
+                        shiftRow = sheet.createRow(rowNumber);
+                    }
+                    Cell employeeCell = shiftRow.createCell(2);
+                    employeeCell.setCellValue(employeeIdToNameMap.get(shift.getEmployeeId()));
+                    rowNumber++;
+                }
+                sheet.autoSizeColumn(0);
+                sheet.autoSizeColumn(1);
+                sheet.autoSizeColumn(2);
+            }
+            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                workbook.write(outputStream);
+                return outputStream.toByteArray();
+            }
+        }
+    }
+}

--- a/optaweb-employee-rostering-frontend/public/assets/translations/en/ExportScheduleModal.yaml
+++ b/optaweb-employee-rostering-frontend/public/assets/translations/en/ExportScheduleModal.yaml
@@ -1,0 +1,6 @@
+export: Export
+exportSchedule: Export Schedule
+fromDate: From Date
+toDate: To Date
+forSpots: For Spots
+selectSpots: Select Spots

--- a/optaweb-employee-rostering-frontend/public/assets/translations/en/ShiftRosterPage.yaml
+++ b/optaweb-employee-rostering-frontend/public/assets/translations/en/ShiftRosterPage.yaml
@@ -2,6 +2,7 @@
 createShift: Create Shift
 reschedule: Reschedule
 commitChanges: Commit Changes
+exportToExcel: Export to Excel
 noSpots:
   <0>There are no Wards</0>
   <1>

--- a/optaweb-employee-rostering-frontend/src/store/contract/selectors.ts
+++ b/optaweb-employee-rostering-frontend/src/store/contract/selectors.ts
@@ -23,11 +23,21 @@ export const getContractById = (state: AppState, id: number): Contract => {
   return state.contractList.contractMapById.get(id) as Contract;
 };
 
+let oldContractMapById: Map<number, Contract> | null = null;
+let contractListForOldContractMapById: Contract[] | null = null;
+
 export const getContractList = (state: AppState): Contract[] => {
   if (state.contractList.isLoading) {
     return [];
   }
+  if (oldContractMapById === state.contractList.contractMapById && contractListForOldContractMapById !== null) {
+    return contractListForOldContractMapById;
+  }
+
   const out: Contract[] = [];
   state.contractList.contractMapById.forEach((value, key) => out.push(getContractById(state, key)));
+
+  oldContractMapById = state.contractList.contractMapById;
+  contractListForOldContractMapById = out;
   return out;
 };

--- a/optaweb-employee-rostering-frontend/src/store/employee/selectors.ts
+++ b/optaweb-employee-rostering-frontend/src/store/employee/selectors.ts
@@ -31,11 +31,21 @@ export const getEmployeeById = (state: AppState, id: number): Employee => {
   };
 };
 
+let oldEmployeeMapById: Map<number, DomainObjectView<Employee>> | null = null;
+let employeeListForOldEmployeeMapById: Employee[] | null = null;
+
 export const getEmployeeList = (state: AppState): Employee[] => {
   if (state.employeeList.isLoading || state.skillList.isLoading || state.contractList.isLoading) {
     return [];
   }
+  if (oldEmployeeMapById === state.employeeList.employeeMapById && employeeListForOldEmployeeMapById !== null) {
+    return employeeListForOldEmployeeMapById;
+  }
+
   const out: Employee[] = [];
   state.employeeList.employeeMapById.forEach((value, key) => out.push(getEmployeeById(state, key)));
+
+  oldEmployeeMapById = state.employeeList.employeeMapById;
+  employeeListForOldEmployeeMapById = out;
   return out;
 };

--- a/optaweb-employee-rostering-frontend/src/store/skill/selectors.ts
+++ b/optaweb-employee-rostering-frontend/src/store/skill/selectors.ts
@@ -23,11 +23,22 @@ export const getSkillById = (state: AppState, id: number): Skill => {
   return state.skillList.skillMapById.get(id) as Skill;
 };
 
+
+let oldSkillMapById: Map<number, Skill> | null = null;
+let skillListForOldSkillMapById: Skill[] | null = null;
+
 export const getSkillList = (state: AppState): Skill[] => {
   if (state.skillList.isLoading) {
     return [];
   }
+  if (oldSkillMapById === state.skillList.skillMapById && skillListForOldSkillMapById !== null) {
+    return skillListForOldSkillMapById;
+  }
+
   const out: Skill[] = [];
   state.skillList.skillMapById.forEach((value, key) => out.push(getSkillById(state, key)));
+
+  oldSkillMapById = state.skillList.skillMapById;
+  skillListForOldSkillMapById = out;
   return out;
 };

--- a/optaweb-employee-rostering-frontend/src/store/spot/selectors.ts
+++ b/optaweb-employee-rostering-frontend/src/store/spot/selectors.ts
@@ -29,11 +29,21 @@ export const getSpotById = (state: AppState, id: number): Spot => {
   };
 };
 
+let oldSpotMapById: Map<number, DomainObjectView<Spot>> | null = null;
+let spotListForOldSpotMapById: Spot[] | null = null;
+
 export const getSpotList = (state: AppState): Spot[] => {
   if (state.spotList.isLoading || state.skillList.isLoading) {
     return [];
   }
+  if (oldSpotMapById === state.spotList.spotMapById && spotListForOldSpotMapById !== null) {
+    return spotListForOldSpotMapById;
+  }
+
   const out: Spot[] = [];
   state.spotList.spotMapById.forEach((value, key) => out.push(getSpotById(state, key)));
+
+  oldSpotMapById = state.spotList.spotMapById;
+  spotListForOldSpotMapById = out;
   return out;
 };

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/CurrentShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/CurrentShiftRosterPage.tsx
@@ -283,12 +283,13 @@ export class ShiftRosterPage extends React.Component<Props, State> {
           });
         } },
       {
-        name: 'Export to Excel',
+        name: t('exportToExcel'),
         action: () => {
           this.setState({
             isExportingSchedule: true,
           });
-        }
+        },
+        isDisabled: this.props.isSolving,
       },
     ];
 

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/CurrentShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/CurrentShiftRosterPage.tsx
@@ -40,6 +40,7 @@ import { getPropsFromUrl, setPropsInUrl, UrlProps } from 'util/BookmarkableUtils
 import { IndictmentSummary } from 'domain/indictment/IndictmentSummary';
 import ShiftEvent, { getShiftColor, ShiftPopupHeader, ShiftPopupBody } from './ShiftEvent';
 import EditShiftModal from './EditShiftModal';
+import ExportScheduleModal from './ExportScheduleModal';
 
 interface StateProps {
   tenantId: number;
@@ -106,6 +107,7 @@ const mapDispatchToProps: DispatchProps = {
 export type Props = RouteComponentProps & StateProps & DispatchProps & WithTranslation;
 interface State {
   isCreatingOrEditingShift: boolean;
+  isExportingSchedule: boolean;
   selectedShift?: Shift;
   firstLoad: boolean;
 }
@@ -121,6 +123,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
     this.getDayStyle = this.getDayStyle.bind(this);
     this.state = {
       isCreatingOrEditingShift: false,
+      isExportingSchedule: false,
       firstLoad: true,
     };
   }
@@ -279,6 +282,14 @@ export class ShiftRosterPage extends React.Component<Props, State> {
             isCreatingOrEditingShift: true,
           });
         } },
+      {
+        name: 'Export to Excel',
+        action: () => {
+          this.setState({
+            isExportingSchedule: true,
+          });
+        }
+      },
     ];
 
     return (
@@ -355,6 +366,14 @@ export class ShiftRosterPage extends React.Component<Props, State> {
             this.setState({ isCreatingOrEditingShift: false });
           }}
           onClose={() => this.setState({ isCreatingOrEditingShift: false })}
+        />
+        <ExportScheduleModal
+          isOpen={this.state.isExportingSchedule}
+          onClose={() => {
+            this.setState({ isExportingSchedule: false });
+          }}
+          defaultFromDate={startDate}
+          defaultToDate={endDate}
         />
         <Schedule<Shift>
           key={this.props.shownSpotList[0].id}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ExportScheduleModal.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ExportScheduleModal.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Modal, Button, ButtonVariant, Form, InputGroup, Label } from '@patternfly/react-core';
+import DatePicker from 'react-datepicker';
+import { useTranslation } from 'react-i18next';
+import MultiTypeaheadSelectInput from 'ui/components/MultiTypeaheadSelectInput';
+import { Spot } from 'domain/Spot';
+import { AppState } from 'store/types';
+import { spotSelectors } from 'store/spot';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+interface StateProps {
+    tenantId: number;
+    spotList: Spot[];
+};
+
+interface OwnProps {
+    isOpen: boolean;
+    onClose: () => void;
+    defaultFromDate: Date;
+    defaultToDate: Date;
+};
+
+const mapStateToProps = (state: AppState, ownProps: OwnProps): StateProps & OwnProps => ({
+  ...ownProps,
+  tenantId: state.tenantData.currentTenantId,
+  spotList: spotSelectors.getSpotList(state),
+});
+
+export const ExportScheduleModal : React.FC<StateProps & OwnProps> = props => {
+  const { t } = useTranslation('ExportScheduleModal');
+  const [ fromDate, setFromDate ] = React.useState<Date | null>(null);
+  const [ toDate, setToDate ] = React.useState<Date | null>(null);
+  const [ exportedSpots, setExportedSpots ] = React.useState<Spot[]>([]);
+  
+  React.useEffect(() => {
+    if (props.isOpen) {
+      setFromDate(props.defaultFromDate);
+      setToDate(props.defaultToDate);
+      setExportedSpots(props.spotList);
+    }
+  }, [props.isOpen, props.defaultFromDate, props.defaultToDate, props.spotList]);
+  
+  const spotSet = (exportedSpots.length > 0)? exportedSpots.map(s => `${s.id}`).reduce((prev,next) => `${prev},${next}`) : null;
+  
+  let exportUrl = '_blank';
+  if (spotSet && toDate && fromDate) {
+    exportUrl = `${process.env.REACT_APP_BACKEND_URL}/rest/tenant/${props.tenantId}/roster/shiftRosterView/excel?` +
+                    `startDate=${moment(fromDate as Date).format('YYYY-MM-DD')}&` +
+                    `endDate=${moment(toDate as Date).format('YYYY-MM-DD')}&spotList=${spotSet}`;
+  }
+  const exportSchedule = () => {
+    props.onClose();
+  };
+  
+  return (
+    <Modal
+      title="Export Schedule"
+      isOpen={props.isOpen}
+      onClose={props.onClose}
+      actions={
+          [
+            <Button
+              aria-label="Close Modal"
+              variant={ButtonVariant.tertiary}
+              key={0}
+              onClick={props.onClose}
+            >
+              {t('close')}
+            </Button>,
+            <a href={exportUrl}
+               className="pf-c-button pf-m-primary"
+               download
+               onClick={exportSchedule}>Export</a>
+          ]
+        }
+        isSmall
+    >
+      <Form id="modal-element" onSubmit={e => e.preventDefault()}>
+          <InputGroup>
+            <Label>From Date</Label>
+            <DatePicker
+              aria-label="From Date"
+              selected={fromDate}
+              onChange={setFromDate}
+            />
+          </InputGroup>
+          <InputGroup>
+            <Label>To Date</Label>
+            <DatePicker
+              aria-label="To Date"
+              selected={toDate}
+              onChange={setToDate}
+            />
+          </InputGroup>
+          <InputGroup>
+            <Label>For Spots</Label>
+            <MultiTypeaheadSelectInput
+              aria-label="For Spots"
+              emptyText="Select Spots..."
+              value={exportedSpots}
+              options={props.spotList}
+              optionToStringMap={spot => spot.name}
+              onChange={setExportedSpots}
+            />
+          </InputGroup>
+        </Form>
+    </Modal>
+  );  
+};
+
+export default connect(mapStateToProps)(ExportScheduleModal);

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
@@ -283,12 +283,13 @@ export class ShiftRosterPage extends React.Component<Props, State> {
           });
         } },
       {
-        name: 'Export to Excel',
+        name: t('exportToExcel'),
         action: () => {
           this.setState({
             isExportingSchedule: true,
           });
-        }
+        },
+        isDisabled: this.props.isSolving,
       },
     ];
 

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/ShiftRosterPage.tsx
@@ -40,6 +40,7 @@ import { getPropsFromUrl, setPropsInUrl, UrlProps } from 'util/BookmarkableUtils
 import { IndictmentSummary } from 'domain/indictment/IndictmentSummary';
 import ShiftEvent, { getShiftColor, ShiftPopupHeader, ShiftPopupBody } from './ShiftEvent';
 import EditShiftModal from './EditShiftModal';
+import ExportScheduleModal from './ExportScheduleModal';
 
 interface StateProps {
   tenantId: number;
@@ -106,6 +107,7 @@ const mapDispatchToProps: DispatchProps = {
 export type Props = RouteComponentProps & StateProps & DispatchProps & WithTranslation;
 interface State {
   isCreatingOrEditingShift: boolean;
+  isExportingSchedule: boolean;
   selectedShift?: Shift;
   firstLoad: boolean;
 }
@@ -121,6 +123,7 @@ export class ShiftRosterPage extends React.Component<Props, State> {
     this.getDayStyle = this.getDayStyle.bind(this);
     this.state = {
       isCreatingOrEditingShift: false,
+      isExportingSchedule: false,
       firstLoad: true,
     };
   }
@@ -279,6 +282,14 @@ export class ShiftRosterPage extends React.Component<Props, State> {
             isCreatingOrEditingShift: true,
           });
         } },
+      {
+        name: 'Export to Excel',
+        action: () => {
+          this.setState({
+            isExportingSchedule: true,
+          });
+        }
+      },
     ];
 
     return (
@@ -354,6 +365,14 @@ export class ShiftRosterPage extends React.Component<Props, State> {
             this.setState({ isCreatingOrEditingShift: false });
           }}
           onClose={() => this.setState({ isCreatingOrEditingShift: false })}
+        />
+        <ExportScheduleModal
+          isOpen={this.state.isExportingSchedule}
+          onClose={() => {
+            this.setState({ isExportingSchedule: false });
+          }}
+          defaultFromDate={startDate}
+          defaultToDate={endDate}
         />
         <Schedule<Shift>
           key={this.props.shownSpotList[0].id}

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
@@ -116,7 +116,8 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
           },
           Object {
             "action": [Function],
-            "name": "Export to Excel",
+            "isDisabled": false,
+            "name": "Trans(i18nKey=exportToExcel)",
           },
         ]
       }
@@ -362,7 +363,8 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
           },
           Object {
             "action": [Function],
-            "name": "Export to Excel",
+            "isDisabled": false,
+            "name": "Trans(i18nKey=exportToExcel)",
           },
         ]
       }
@@ -636,7 +638,8 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
           },
           Object {
             "action": [Function],
-            "name": "Export to Excel",
+            "isDisabled": true,
+            "name": "Trans(i18nKey=exportToExcel)",
           },
         ]
       }

--- a/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/shift/__snapshots__/ShiftRosterPage.test.tsx.snap
@@ -114,6 +114,10 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
             "action": [Function],
             "name": "Trans(i18nKey=createShift)",
           },
+          Object {
+            "action": [Function],
+            "name": "Export to Excel",
+          },
         ]
       }
     />
@@ -124,6 +128,12 @@ exports[`Shift Roster Page should render correctly when creating a new shift via
     onClose={[Function]}
     onDelete={[Function]}
     onSave={[Function]}
+  />
+  <Connect(ExportScheduleModal)
+    defaultFromDate={2018-07-01T00:00:00.000Z}
+    defaultToDate={2018-07-07T23:59:59.999Z}
+    isOpen={false}
+    onClose={[Function]}
   />
   <Schedule
     dayStyle={[Function]}
@@ -350,6 +360,10 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
             "action": [Function],
             "name": "Trans(i18nKey=createShift)",
           },
+          Object {
+            "action": [Function],
+            "name": "Export to Excel",
+          },
         ]
       }
     />
@@ -360,6 +374,12 @@ exports[`Shift Roster Page should render correctly when loaded 1`] = `
     onClose={[Function]}
     onDelete={[Function]}
     onSave={[Function]}
+  />
+  <Connect(ExportScheduleModal)
+    defaultFromDate={2018-07-01T00:00:00.000Z}
+    defaultToDate={2018-07-07T23:59:59.999Z}
+    isOpen={false}
+    onClose={[Function]}
   />
   <Schedule
     dayStyle={[Function]}
@@ -614,6 +634,10 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
             "action": [Function],
             "name": "Trans(i18nKey=createShift)",
           },
+          Object {
+            "action": [Function],
+            "name": "Export to Excel",
+          },
         ]
       }
     />
@@ -624,6 +648,12 @@ exports[`Shift Roster Page should render correctly when solving 1`] = `
     onClose={[Function]}
     onDelete={[Function]}
     onSave={[Function]}
+  />
+  <Connect(ExportScheduleModal)
+    defaultFromDate={2018-07-01T00:00:00.000Z}
+    defaultToDate={2018-07-07T23:59:59.999Z}
+    isOpen={false}
+    onClose={[Function]}
   />
   <Schedule
     dayStyle={[Function]}


### PR DESCRIPTION
Current format is:
Start, End, Employee

with the following caveats to maximize human readability:

- Shifts with the same date and time in the same spot don't have their date/time repeated
- Employee(s) are 1 line under date/time

Ex:

Start,       End,           Employee
date 1,     date 2,
                                  Amy
                                  Bob
date 3,     date 4,
                                  Charlie 