### PR TITLE
Change name of Openshift project

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -104,7 +104,7 @@ b. log in as "developer".
 +
 [source,subs="quotes"]
 ----
-oc new-project _project_name_
+oc new-project _project-name_
 ----
 
 4. Run the script:


### PR DESCRIPTION
It is impossible to use oc new-project project_name us it suggested in readme 

The ProjectRequest "project_name" is invalid: metadata.name: Invalid value: "project_name": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')