### PR TITLE
Replace DatePicker component used in WeekPicker to prevent bad CSS styling (#463)

### DIFF
--- a/optaweb-employee-rostering-frontend/package-lock.json
+++ b/optaweb-employee-rostering-frontend/package-lock.json
@@ -2725,20 +2725,6 @@
       "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.0.tgz",
       "integrity": "sha512-tHzSlWCmb1GjxjiPRTju7i2bQigYriFDmCpaf1dC4SebFRjhBiuRpIxy5oI3b3ZMg9OzqGnApdZJrlYSwEUJAg=="
     },
-    "@wojtekmaj/react-daterange-picker": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wojtekmaj/react-daterange-picker/-/react-daterange-picker-2.5.0.tgz",
-      "integrity": "sha512-UNboE9cvsVTWjV+VAHPJqY+5KL5Pd3KSD10rZBkVdJLIj0at1TvzXRLA7pE/CwYqQvkeKHa9S169hbH8tLdFKA==",
-      "requires": {
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "prop-types": "^15.6.0",
-        "react-calendar": "^2.19.1",
-        "react-date-picker": "^7.9.0",
-        "react-fit": "^1.0.3",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/optaweb-employee-rostering-frontend/package-lock.json
+++ b/optaweb-employee-rostering-frontend/package-lock.json
@@ -2720,11 +2720,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@wojtekmaj/date-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.0.0.tgz",
-      "integrity": "sha512-tHzSlWCmb1GjxjiPRTju7i2bQigYriFDmCpaf1dC4SebFRjhBiuRpIxy5oI3b3ZMg9OzqGnApdZJrlYSwEUJAg=="
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5657,11 +5652,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "detect-element-overflow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-1.2.0.tgz",
-      "integrity": "sha512-Jtr9ivYPhpd9OJux+hjL0QjUKiS1Ghgy8tvIufUjFslQgIWvgGr4mn57H190APbKkiOmXnmtMI6ytaKzMusecg=="
-    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -7678,14 +7668,6 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "get-user-locale": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.3.0.tgz",
-      "integrity": "sha512-c5N8P0upjxCF9unIC2vTA+B+8nN7kU/D/TeItMAVYhWIIksyoULM1aflKflXM3w+Ij6vF/JZys+QcwIoDuy3Ag==",
-      "requires": {
-        "lodash.once": "^4.1.1"
       }
     },
     "get-value": {
@@ -11109,7 +11091,8 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -11308,11 +11291,6 @@
         }
       }
     },
-    "make-event-props": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.2.0.tgz",
-      "integrity": "sha512-BmWFkm/jZzVH9A0tEBdkjAARUz/eha+5IRyfOndeSMKRadkgR5DawoBHoRwLxkYmjJOI5bHkXKpaZocxj+dKgg=="
-    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -11454,11 +11432,6 @@
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
       }
-    },
-    "merge-class-names": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.3.0.tgz",
-      "integrity": "sha512-k0Qaj36VBpKgdc8c188LEZvo6v/zzry/FUufwopWbMSp6/knfVFU/KIB55/hJjeIpg18IH2WskXJCRnM/1BrdQ=="
     },
     "merge-deep": {
       "version": "3.0.2",
@@ -14190,17 +14163,6 @@
         "warning": "^4.0.2"
       }
     },
-    "react-calendar": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-2.19.2.tgz",
-      "integrity": "sha512-zKbWxwmYEg84grFsCJz9EYpnGqsZy0iV67dHzkVE0EhBdXMg2eISBQYvw4+t8zdy5ySxQkDhUW8X8ERbSyZPVw==",
-      "requires": {
-        "get-user-locale": "^1.2.0",
-        "merge-class-names": "^1.1.1",
-        "prop-types": "^15.6.0",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "react-color": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.1.tgz",
@@ -14212,22 +14174,6 @@
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
         "tinycolor2": "^1.4.1"
-      }
-    },
-    "react-date-picker": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/react-date-picker/-/react-date-picker-7.10.0.tgz",
-      "integrity": "sha512-5lyWOeSMeCmzqKTd5X1W2jaxPU67Pu06IMmjKmh/tgw0u6QM2UHkwmBlZnMoBuaxrjMlc33HrssxB4EkUyqzHg==",
-      "requires": {
-        "@wojtekmaj/date-utils": "^1.0.0",
-        "get-user-locale": "^1.2.0",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "prop-types": "^15.6.0",
-        "react-calendar": "^2.19.1",
-        "react-fit": "^1.0.3",
-        "react-lifecycles-compat": "^3.0.4",
-        "update-input-width": "^1.1.1"
       }
     },
     "react-datepicker": {
@@ -14544,15 +14490,6 @@
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
-    },
-    "react-fit": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/react-fit/-/react-fit-1.0.5.tgz",
-      "integrity": "sha512-TTR/nfFi0d+pJ1ukoKXjd22a9dVbAXFf7IVjny3RIzoI7gt4y26jHds8GHY8jWRy3kDNpQyrC70JOVnkmxoebw==",
-      "requires": {
-        "detect-element-overflow": "^1.1.1",
-        "prop-types": "^15.6.0"
-      }
     },
     "react-grid-layout": {
       "version": "0.17.1",
@@ -17466,11 +17403,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
-    },
-    "update-input-width": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.2.1.tgz",
-      "integrity": "sha512-zygDshqDb2C2/kgfoD423n5htv/3OBF7aTaz2u2zZy998EJki8njOHOeZjKEd8XSYeDziIX1JXfMsKaIRJeJ/Q=="
     },
     "upper-case": {
       "version": "1.1.3",

--- a/optaweb-employee-rostering-frontend/package.json
+++ b/optaweb-employee-rostering-frontend/package.json
@@ -17,7 +17,6 @@
     "react": "^16.13.1",
     "react-big-calendar": "^0.23.0",
     "react-color": "2.18.1",
-    "react-date-picker": "^7.10.0",
     "react-datepicker": "^2.11.0",
     "react-dom": "^16.13.1",
     "react-grid-layout": "^0.17.1",

--- a/optaweb-employee-rostering-frontend/package.json
+++ b/optaweb-employee-rostering-frontend/package.json
@@ -6,7 +6,6 @@
     "@patternfly/react-core": "^3.153.13",
     "@patternfly/react-icons": "^3.14.39",
     "@patternfly/react-table": "^2.25.6",
-    "@wojtekmaj/react-daterange-picker": "^2.5.0",
     "axios": "^0.19.2",
     "color": "^3.1.2",
     "date-fns": "^2.9.0",

--- a/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.test.tsx
@@ -23,7 +23,7 @@ import 'moment/locale/en-ca';
 import MockDate from 'mockdate';
 import { Button, Text } from '@patternfly/react-core';
 import { HistoryIcon, CalendarIcon } from '@patternfly/react-icons';
-import WeekPicker from './WeekPicker';
+import WeekPicker, { DateRangeInputElement } from './WeekPicker';
 
 describe('WeekPicker component', () => {
   beforeAll(() => {
@@ -54,57 +54,6 @@ describe('WeekPicker component', () => {
       .toBeCalledWith(moment('2019-07-07').toDate(), moment('2019-07-07').endOf('week').toDate());
   });
 
-  it('should go to current week when the reset button is clicked', () => {
-    const solvingStartTime = moment('2019-07-23').toDate();
-    MockDate.set(solvingStartTime);
-    const onChange = jest.fn();
-    const onClick = jest.fn();
-    const date = moment('2019-07-03').toDate();
-    const weekPicker = shallow(<WeekPicker value={date} onChange={onChange} />);
-    const customInput = shallow((weekPicker.find(DatePicker).prop('customInput') as JSX.Element));
-    customInput.setProps({ value: date, onClick });
-
-    customInput.find(Button).filterWhere(p => p.contains(<HistoryIcon />)).simulate('click');
-    expect(onClick).not.toBeCalled();
-    expect(onChange).toBeCalled();
-    expect(onChange)
-      .toBeCalledWith(moment('2019-07-21').toDate(), moment('2019-07-21').endOf('week').toDate());
-  });
-
-  it('should open the week selector if the input or calendar icon is clicked', () => {
-    const solvingStartTime = moment('2019-07-23').toDate();
-    MockDate.set(solvingStartTime);
-    const onChange = jest.fn();
-    const onClick = jest.fn();
-    const date = moment('2019-07-03').toDate();
-    const weekPicker = shallow(<WeekPicker value={date} onChange={onChange} />);
-    const customInput = shallow((weekPicker.find(DatePicker).prop('customInput') as JSX.Element));
-    customInput.setProps({ value: date, onClick });
-
-    customInput.find(Button).filterWhere(p => p.contains(<CalendarIcon />)).simulate('click');
-    expect(onClick).toBeCalled();
-    expect(onChange).not.toBeCalled();
-
-    onClick.mockClear();
-
-    customInput.find(Text).simulate('click');
-    expect(onClick).toBeCalled();
-    expect(onChange).not.toBeCalled();
-  });
-
-  it('custom input should render correctly', () => {
-    const solvingStartTime = moment('2019-07-23').toDate();
-    MockDate.set(solvingStartTime);
-    const onChange = jest.fn();
-    const onClick = jest.fn();
-    const date = moment('2019-07-03').toDate();
-    const weekPicker = shallow(<WeekPicker value={date} onChange={onChange} />);
-    const customInput = shallow((weekPicker.find(DatePicker).prop('customInput') as JSX.Element));
-    customInput.setProps({ value: date, onClick });
-
-    expect(customInput).toMatchSnapshot();
-  });
-
   it('should go to the week containing a day when the day is clicked', () => {
     const onChange = jest.fn();
     const weekPicker = shallow(<WeekPicker value={moment('2019-07-03').toDate()} onChange={onChange} />);
@@ -112,5 +61,72 @@ describe('WeekPicker component', () => {
     expect(onChange).toBeCalled();
     expect(onChange)
       .toBeCalledWith(moment('2019-07-28').toDate(), moment('2019-07-28').endOf('week').toDate());
+  });
+});
+
+describe('WeekPicker custom input component', () => {
+  beforeAll(() => {
+    moment.locale('en');
+  });
+
+  it('custom input should render correctly', () => {
+    const solvingStartTime = moment('2019-07-23').toDate();
+    MockDate.set(solvingStartTime);
+    const goToCurrentWeek = jest.fn();
+    const date = moment('2019-07-03').toDate();
+    const datePickerRef = { current: { setOpen: jest.fn() } };
+    const customInput = shallow(
+      <DateRangeInputElement
+        value={date}
+        datePickerRef={datePickerRef as any as React.RefObject<DatePicker>}
+        goToCurrentWeek={goToCurrentWeek}
+      />,
+    );
+
+    expect(customInput).toMatchSnapshot();
+  });
+
+  it('should go to current week when the reset button is clicked', () => {
+    const solvingStartTime = moment('2019-07-23').toDate();
+    MockDate.set(solvingStartTime);
+    const goToCurrentWeek = jest.fn();
+    const date = moment('2019-07-03').toDate();
+    const datePickerRef = { current: { setOpen: jest.fn() } };
+    const customInput = shallow(
+      <DateRangeInputElement
+        value={date}
+        datePickerRef={datePickerRef as any as React.RefObject<DatePicker>}
+        goToCurrentWeek={goToCurrentWeek}
+      />,
+    );
+
+    customInput.find(Button).filterWhere(p => p.contains(<HistoryIcon />)).simulate('click');
+    expect(datePickerRef.current.setOpen).not.toBeCalled();
+    expect(goToCurrentWeek).toBeCalled();
+  });
+
+  it('should open the week selector if the input or calendar icon is clicked', () => {
+    const solvingStartTime = moment('2019-07-23').toDate();
+    MockDate.set(solvingStartTime);
+    const goToCurrentWeek = jest.fn();
+    const date = moment('2019-07-03').toDate();
+    const datePickerRef = { current: { setOpen: jest.fn() } };
+    const customInput = shallow(
+      <DateRangeInputElement
+        value={date}
+        datePickerRef={datePickerRef as any as React.RefObject<DatePicker>}
+        goToCurrentWeek={goToCurrentWeek}
+      />,
+    );
+
+    customInput.find(Button).filterWhere(p => p.contains(<CalendarIcon />)).simulate('click');
+    expect(datePickerRef.current.setOpen).toBeCalled();
+    expect(goToCurrentWeek).not.toBeCalled();
+
+    datePickerRef.current.setOpen.mockClear();
+
+    customInput.find(Text).simulate('click');
+    expect(datePickerRef.current.setOpen).toBeCalled();
+    expect(goToCurrentWeek).not.toBeCalled();
   });
 });

--- a/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.tsx
@@ -52,44 +52,54 @@ export default class WeekPicker extends React.Component<WeekPickerProps> {
   }
 
   render() {
-    const DateRangeInputElement = (dateRangeInputProps?: { value?: Date; onClick?: () => void }) => (
-      <div
-        className="pf-c-form-control"
-        style={{
-          display: 'grid',
-          height: 'auto',
-          gridTemplateColumns: '1fr auto auto',
-          alignItems: 'center',
-        }}
-      >
-        <Text
-          onClick={dateRangeInputProps ? dateRangeInputProps.onClick : undefined}
-        >
-          {
-            `${moment(getFirstDayInWeek(this.props.value)).format('L')} - ${
-              moment(getLastDayInWeek(this.props.value)).format('L')}`
-          }
-        </Text>
-        <Button
+    type DatePickerCustomInputProps = { value?: Date; onClick?: () => void };
+
+    // (the stateless functional component is defined in a class component, where
+    //  this = the class this, so it okay to use "this" here)
+    /* eslint-disable react/no-this-in-sfc */
+    const DateRangeInputElement = React.forwardRef<HTMLDivElement, DatePickerCustomInputProps>(
+      (dateRangeInputProps, ref) => (
+        <div
+          ref={ref}
+          className="pf-c-form-control"
           style={{
-            color: 'black',
+            display: 'grid',
+            height: 'auto',
+            gridTemplateColumns: '1fr auto auto',
+            alignItems: 'center',
           }}
-          onClick={() => this.goToCurrentWeek()}
-          variant="link"
         >
-          <HistoryIcon />
-        </Button>
-        <Button
-          style={{
-            color: 'black',
-          }}
-          onClick={dateRangeInputProps ? dateRangeInputProps.onClick : undefined}
-          variant="link"
-        >
-          <CalendarIcon />
-        </Button>
-      </div>
+          <Text
+            onClick={dateRangeInputProps ? dateRangeInputProps.onClick : undefined}
+          >
+            {
+              `${moment(getFirstDayInWeek(this.props.value)).format('L')} - ${
+                moment(getLastDayInWeek(this.props.value)).format('L')}`
+            }
+          </Text>
+          <Button
+            style={{
+              color: 'black',
+            }}
+            onClick={() => this.goToCurrentWeek()}
+            variant="link"
+          >
+            <HistoryIcon />
+          </Button>
+          <Button
+            style={{
+              color: 'black',
+            }}
+            onClick={dateRangeInputProps ? dateRangeInputProps.onClick : undefined}
+            variant="link"
+          >
+            <CalendarIcon />
+          </Button>
+        </div>
+      ),
     );
+    /* eslint-enable react/no-this-in-sfc */
+
     return (
       <div className="week-picker-container">
         <Button

--- a/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.tsx
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 import React from 'react';
-// @ts-ignore
-import DatePicker from '@wojtekmaj/react-daterange-picker';
+import DatePicker from 'react-datepicker';
 import moment from 'moment';
-import { HistoryIcon } from '@patternfly/react-icons';
+import { HistoryIcon, CalendarIcon } from '@patternfly/react-icons';
 import './WeekPicker.css';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Text } from '@patternfly/react-core';
 
 export interface WeekPickerProps {
   value: Date;
   minDate?: Date;
   maxDate?: Date;
   onChange: (weekStartDate: Date, weekEndDate: Date) => void;
-}
-
-export interface WeekPickerState {
-  isOpen: boolean;
 }
 
 function getFirstDayInWeek(dateInWeek: Date): Date {
@@ -40,12 +35,7 @@ function getLastDayInWeek(dateInWeek: Date): Date {
   return moment(dateInWeek).endOf('week').toDate();
 }
 
-export default class WeekPicker extends React.Component<WeekPickerProps, WeekPickerState> {
-  constructor(props: WeekPickerProps) {
-    super(props);
-    this.state = { isOpen: false };
-  }
-
+export default class WeekPicker extends React.Component<WeekPickerProps> {
   goToCurrentWeek() {
     this.goToWeekContaining(new Date());
   }
@@ -53,15 +43,53 @@ export default class WeekPicker extends React.Component<WeekPickerProps, WeekPic
   goToWeekContaining(date: Date) {
     if (this.props.minDate && getFirstDayInWeek(date) < getFirstDayInWeek(this.props.minDate)) {
       this.goToWeekContaining(this.props.minDate);
-    } else if (this.props.maxDate && getLastDayInWeek(date) > getLastDayInWeek(this.props.maxDate)) {
+      return;
+    } if (this.props.maxDate && getLastDayInWeek(date) > getLastDayInWeek(this.props.maxDate)) {
       this.goToWeekContaining(this.props.maxDate);
+      return;
     }
     this.props.onChange(getFirstDayInWeek(date), getLastDayInWeek(date));
-    this.setState({ isOpen: false });
   }
 
   render() {
-    const locale = moment.locale();
+    const DateRangeInputElement = (dateRangeInputProps?: { value?: Date; onClick?: () => void }) => (
+      <div
+        className="pf-c-form-control"
+        style={{
+          display: 'grid',
+          height: 'auto',
+          gridTemplateColumns: '1fr auto auto',
+          alignItems: 'center',
+        }}
+      >
+        <Text
+          onClick={dateRangeInputProps ? dateRangeInputProps.onClick : undefined}
+        >
+          {
+            `${moment(getFirstDayInWeek(this.props.value)).format('L')} - ${
+              moment(getLastDayInWeek(this.props.value)).format('L')}`
+          }
+        </Text>
+        <Button
+          style={{
+            color: 'black',
+          }}
+          onClick={() => this.goToCurrentWeek()}
+          variant="link"
+        >
+          <HistoryIcon />
+        </Button>
+        <Button
+          style={{
+            color: 'black',
+          }}
+          onClick={dateRangeInputProps ? dateRangeInputProps.onClick : undefined}
+          variant="link"
+        >
+          <CalendarIcon />
+        </Button>
+      </div>
+    );
     return (
       <div className="week-picker-container">
         <Button
@@ -90,20 +118,19 @@ export default class WeekPicker extends React.Component<WeekPickerProps, WeekPic
           </svg>
         </Button>
         <DatePicker
-          className="week-picker"
-          locale={
-            /* moment intreprets "en" as "en-US", this intreprets "en" as "en-GB" */
-            locale === 'en' ? 'en-US' : locale
-          }
-          value={[getFirstDayInWeek(this.props.value), getLastDayInWeek(this.props.value)]}
-          onChange={() => this.goToCurrentWeek()}
-          onClickDay={(value: Date) => this.goToWeekContaining(value)}
-          onCalendarOpen={() => this.setState({ isOpen: true })}
-          onCalendarClose={() => this.setState({ isOpen: false })}
+          selected={getFirstDayInWeek(this.props.value)}
+          startDate={getFirstDayInWeek(this.props.value)}
+          endDate={getLastDayInWeek(this.props.value)}
+          onChange={(date) => {
+            if (date !== null) {
+              this.goToWeekContaining(date);
+            } else {
+              this.goToCurrentWeek();
+            }
+          }}
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
-          isOpen={this.state.isOpen}
-          clearIcon={<HistoryIcon />}
+          customInput={<DateRangeInputElement />}
           required
         />
         <Button

--- a/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/WeekPicker.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/WeekPicker.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`WeekPicker component should render correctly 1`] = `
   </Component>
   <t
     allowSameDay={false}
-    customInput={<DateRangeInputElement />}
+    customInput={<ForwardRef />}
     dateFormat="MM/dd/yyyy"
     dateFormatCalendar="LLLL yyyy"
     disabled={false}

--- a/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/WeekPicker.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/WeekPicker.test.tsx.snap
@@ -1,57 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WeekPicker component custom input should render correctly 1`] = `
-<div
-  className="pf-c-form-control"
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "grid",
-      "gridTemplateColumns": "1fr auto auto",
-      "height": "auto",
-    }
-  }
->
-  <Text
-    onClick={[MockFunction]}
-  >
-    06/30/2019 - 07/06/2019
-  </Text>
-  <Component
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "black",
-      }
-    }
-    variant="link"
-  >
-    <HistoryIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-      title={null}
-    />
-  </Component>
-  <Component
-    onClick={[MockFunction]}
-    style={
-      Object {
-        "color": "black",
-      }
-    }
-    variant="link"
-  >
-    <CalendarIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-      title={null}
-    />
-  </Component>
-</div>
-`;
-
 exports[`WeekPicker component should render correctly 1`] = `
 <div
   className="week-picker-container"
@@ -82,7 +30,16 @@ exports[`WeekPicker component should render correctly 1`] = `
   </Component>
   <t
     allowSameDay={false}
-    customInput={<ForwardRef />}
+    customInput={
+      <ForwardRef
+        datePickerRef={
+          Object {
+            "current": null,
+          }
+        }
+        goToCurrentWeek={[Function]}
+      />
+    }
     dateFormat="MM/dd/yyyy"
     dateFormatCalendar="LLLL yyyy"
     disabled={false}
@@ -149,6 +106,58 @@ exports[`WeekPicker component should render correctly 1`] = `
         transform=""
       />
     </svg>
+  </Component>
+</div>
+`;
+
+exports[`WeekPicker custom input component custom input should render correctly 1`] = `
+<div
+  className="pf-c-form-control"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "grid",
+      "gridTemplateColumns": "1fr auto auto",
+      "height": "auto",
+    }
+  }
+>
+  <Text
+    onClick={[Function]}
+  >
+    06/30/2019 - 07/06/2019
+  </Text>
+  <Component
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "black",
+      }
+    }
+    variant="link"
+  >
+    <HistoryIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  </Component>
+  <Component
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "black",
+      }
+    }
+    variant="link"
+  >
+    <CalendarIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
   </Component>
 </div>
 `;

--- a/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/WeekPicker.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/__snapshots__/WeekPicker.test.tsx.snap
@@ -1,117 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WeekPicker component should render correctly when closed 1`] = `
+exports[`WeekPicker component custom input should render correctly 1`] = `
 <div
-  className="week-picker-container"
+  className="pf-c-form-control"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "grid",
+      "gridTemplateColumns": "1fr auto auto",
+      "height": "auto",
+    }
+  }
 >
-  <Component
-    aria-label="Previous Week"
-    onClick={[Function]}
-    variant="plain"
+  <Text
+    onClick={[MockFunction]}
   >
-    <svg
-      aria-hidden="true"
-      fill="currentColor"
-      height="1em"
-      role="img"
-      style={
-        Object {
-          "verticalAlign": "-0.125em",
-        }
+    06/30/2019 - 07/06/2019
+  </Text>
+  <Component
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "black",
       }
-      viewBox="0 0 256 512"
-      width="1em"
-    >
-      <path
-        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-        transform=""
-      />
-    </svg>
+    }
+    variant="link"
+  >
+    <HistoryIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
   </Component>
-  <DateRangePicker
-    calendarIcon={
-      <svg
-        className="react-daterange-picker__calendar-button__icon react-daterange-picker__button__icon"
-        height={19}
-        stroke="black"
-        strokeWidth={2}
-        viewBox="0 0 19 19"
-        width={19}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect
-          fill="none"
-          height="15"
-          width="15"
-          x="2"
-          y="2"
-        />
-        <line
-          x1="6"
-          x2="6"
-          y1="0"
-          y2="4"
-        />
-        <line
-          x1="13"
-          x2="13"
-          y1="0"
-          y2="4"
-        />
-      </svg>
-    }
-    className="week-picker"
-    clearIcon={
-      <HistoryIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-        title={null}
-      />
-    }
-    isOpen={false}
-    locale="en-US"
-    name="daterange"
-    onCalendarClose={[Function]}
-    onCalendarOpen={[Function]}
-    onChange={[Function]}
-    onClickDay={[Function]}
-    required={true}
-    value={
-      Array [
-        2019-06-30T00:00:00.000Z,
-        2019-07-06T23:59:59.999Z,
-      ]
-    }
-  />
   <Component
-    aria-label="Next Week"
-    onClick={[Function]}
-    variant="plain"
-  >
-    <svg
-      aria-hidden="true"
-      fill="currentColor"
-      height="1em"
-      role="img"
-      style={
-        Object {
-          "verticalAlign": "-0.125em",
-        }
+    onClick={[MockFunction]}
+    style={
+      Object {
+        "color": "black",
       }
-      viewBox="0 0 256 512"
-      width="1em"
-    >
-      <path
-        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-        transform=""
-      />
-    </svg>
+    }
+    variant="link"
+  >
+    <CalendarIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
   </Component>
 </div>
 `;
 
-exports[`WeekPicker component should render correctly when opened 1`] = `
+exports[`WeekPicker component should render correctly 1`] = `
 <div
   className="week-picker-container"
 >
@@ -139,61 +80,51 @@ exports[`WeekPicker component should render correctly when opened 1`] = `
       />
     </svg>
   </Component>
-  <DateRangePicker
-    calendarIcon={
-      <svg
-        className="react-daterange-picker__calendar-button__icon react-daterange-picker__button__icon"
-        height={19}
-        stroke="black"
-        strokeWidth={2}
-        viewBox="0 0 19 19"
-        width={19}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect
-          fill="none"
-          height="15"
-          width="15"
-          x="2"
-          y="2"
-        />
-        <line
-          x1="6"
-          x2="6"
-          y1="0"
-          y2="4"
-        />
-        <line
-          x1="13"
-          x2="13"
-          y1="0"
-          y2="4"
-        />
-      </svg>
-    }
-    className="week-picker"
-    clearIcon={
-      <HistoryIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-        title={null}
-      />
-    }
-    isOpen={true}
-    locale="en-US"
-    name="daterange"
+  <t
+    allowSameDay={false}
+    customInput={<DateRangeInputElement />}
+    dateFormat="MM/dd/yyyy"
+    dateFormatCalendar="LLLL yyyy"
+    disabled={false}
+    disabledKeyboardNavigation={false}
+    dropdownMode="scroll"
+    endDate={2019-07-06T23:59:59.999Z}
+    inlineFocusSelectedMonth={false}
+    monthsShown={1}
+    nextMonthButtonLabel="Next Month"
+    nextYearButtonLabel="Next Year"
+    onBlur={[Function]}
     onCalendarClose={[Function]}
     onCalendarOpen={[Function]}
     onChange={[Function]}
-    onClickDay={[Function]}
+    onClickOutside={[Function]}
+    onFocus={[Function]}
+    onInputClick={[Function]}
+    onInputError={[Function]}
+    onKeyDown={[Function]}
+    onMonthChange={[Function]}
+    onSelect={[Function]}
+    onYearChange={[Function]}
+    preventOpenOnFocus={false}
+    previousMonthButtonLabel="Previous Month"
+    previousYearButtonLabel="Previous Year"
+    readOnly={false}
+    renderDayContents={[Function]}
     required={true}
-    value={
-      Array [
-        2019-06-30T00:00:00.000Z,
-        2019-07-06T23:59:59.999Z,
-      ]
-    }
+    selected={2019-06-30T00:00:00.000Z}
+    shouldCloseOnSelect={true}
+    showMonthYearPicker={false}
+    showPopperArrow={true}
+    showPreviousMonths={false}
+    showQuarterYearPicker={false}
+    showTimeInput={false}
+    showTimeSelect={false}
+    startDate={2019-06-30T00:00:00.000Z}
+    strictParsing={false}
+    timeCaption="Time"
+    timeInputLabel="Time"
+    timeIntervals={30}
+    withPortal={false}
   />
   <Component
     aria-label="Next Week"


### PR DESCRIPTION
"@wojtekmaj/react-daterange-picker" has a CSS issue causing it not to load properly at startup.
Replacing it with "react-datepicker" since we already use it in other components and it is more popular and maintained.

Fixes #463.