### PR TITLE
Remove TSLint plugin

### DIFF
--- a/optaweb-employee-rostering-frontend/package-lock.json
+++ b/optaweb-employee-rostering-frontend/package-lock.json
@@ -2507,16 +2507,6 @@
         "tsutils": "^3.17.1"
       }
     },
-    "@typescript-eslint/eslint-plugin-tslint": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.19.0.tgz",
-      "integrity": "sha512-a/0i6Q+GHojT2I+UccTrlBMnH7Y+evy7+Wg95Jiue4t+G+nITXV5hY5nI9tmY/L7P+SCdri9KDXj2lyn5O2F1g==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "2.19.0",
-        "lodash": "^4.17.15"
-      }
-    },
     "@typescript-eslint/experimental-utils": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz",

--- a/optaweb-employee-rostering-frontend/package.json
+++ b/optaweb-employee-rostering-frontend/package.json
@@ -82,7 +82,6 @@
     "@types/uuid": "^7.0.2",
     "@types/yaml": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^2.19.0",
-    "@typescript-eslint/eslint-plugin-tslint": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "cross-env": "^6.0.3",
     "cypress": "^4.11.0",

--- a/optaweb-employee-rostering-frontend/src/ui/pages/rotation/SeatJigsaw.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/pages/rotation/SeatJigsaw.tsx
@@ -27,8 +27,6 @@ import { TimeBucket } from 'domain/TimeBucket';
 import { EditTimeBucketModal } from './EditTimeBucketModal';
 import { Stub, EmployeeNickName } from './EmployeeStub';
 
-/* tslint:disable:no-nested-ternary react/no-array-index-key */
-
 export interface SeatJigsawProps {
   selectedStub: Stub | null;
   timeBucket: TimeBucket;


### PR DESCRIPTION
TSLint plugin has been replaced by new version of ESLint with TypeScript
support a long time ago.