### PR TITLE
Make planning items be in the future

### DIFF
--- a/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
+++ b/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
@@ -77,7 +77,7 @@ describe('A new tenant can be created, who can have their own employees, spots, 
     cy.get('[data-cy=settings]').click();
     cy.get('[data-cy=add-tenant]').click();
     cy.get('[data-cy=name]').type('Test Tenant');
-    cy.get('[data-cy=schedule-start-date]').type(Cypress.moment().format('YYYY-MM-DD'));
+    cy.get('[data-cy=schedule-start-date]').type('2018-01-01');
     cy.get('[data-cy=draft-length]').type('7');
     cy.get('[data-cy=publish-notice]').type('7');
     // TODO: publish length is disabled/not supported by backend, uncomment when supported

--- a/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
+++ b/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
@@ -77,7 +77,7 @@ describe('A new tenant can be created, who can have their own employees, spots, 
     cy.get('[data-cy=settings]').click();
     cy.get('[data-cy=add-tenant]').click();
     cy.get('[data-cy=name]').type('Test Tenant');
-    cy.get('[data-cy=schedule-start-date]').type(Cypress.moment().format("YYYY-MM-DD"));
+    cy.get('[data-cy=schedule-start-date]').type(Cypress.moment().format('YYYY-MM-DD'));
     cy.get('[data-cy=draft-length]').type('7');
     cy.get('[data-cy=publish-notice]').type('7');
     // TODO: publish length is disabled/not supported by backend, uncomment when supported
@@ -127,7 +127,7 @@ describe('A new tenant can be created, who can have their own employees, spots, 
     // Sometimes a shift is not created, so wait to make the test stable
     cy.wait(1500);
     // Plan for the next week
-    cy.get('[aria-label="Next Week"]').click({force: true});
+    cy.get('[aria-label="Next Week"]').click({ force: true });
     dragCreateShift(3, '00:00', '06:00');
 
     // Schedule for 5 seconds

--- a/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
+++ b/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
@@ -77,7 +77,7 @@ describe('A new tenant can be created, who can have their own employees, spots, 
     cy.get('[data-cy=settings]').click();
     cy.get('[data-cy=add-tenant]').click();
     cy.get('[data-cy=name]').type('Test Tenant');
-    cy.get('[data-cy=schedule-start-date]').type('2018-01-01');
+    cy.get('[data-cy=schedule-start-date]').type(Cypress.moment().format("YYYY-MM-DD"));
     cy.get('[data-cy=draft-length]').type('7');
     cy.get('[data-cy=publish-notice]').type('7');
     // TODO: publish length is disabled/not supported by backend, uncomment when supported
@@ -126,7 +126,9 @@ describe('A new tenant can be created, who can have their own employees, spots, 
 
     // Sometimes a shift is not created, so wait to make the test stable
     cy.wait(1500);
-    dragCreateShift(2, '00:00', '06:00');
+    // Plan for the next week
+    cy.get('[aria-label="Next Week"]').click({force: true});
+    dragCreateShift(3, '00:00', '06:00');
 
     // Schedule for 5 seconds
     cy.get('[aria-label="Actions"]').click();


### PR DESCRIPTION
For sake of stable tests, we need to pass valid data that would dynamically adjust

Early the schedule has been trying to plan for the past, since dates
in the test have been written in the stone. Currently, the date of shift planning is related
to the current date and the planning activity is set to the Wednesday of the next week
So 18th of September you will test schedule on the 23rd of September (18 -> next week -> Wed)


### JIRA

[PLANNER-2110](https://issues.redhat.com/browse/PLANNER-2110)

