### PR TITLE
Change innerText => textContent for safari support in dropdown

### DIFF
--- a/optaweb-employee-rostering-frontend/src/ui/components/Actions.test.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/Actions.test.tsx
@@ -44,7 +44,7 @@ describe('Actions component', () => {
 
   it('clicking on a dropdown should call the action', () => {
     const actionsComponent = shallow(<Actions {...mobileProps} />);
-    actionsComponent.find('Dropdown').simulate('select', { currentTarget: { innerText: 'Action 3' } });
+    actionsComponent.find('Dropdown').simulate('select', { currentTarget: { textContent: 'Action 3' } });
     expect(actions[2].action).toBeCalled();
   });
 });

--- a/optaweb-employee-rostering-frontend/src/ui/components/Actions.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/Actions.tsx
@@ -67,7 +67,7 @@ export const Actions: FC<Props & SizeMeProps> = ({ actions, size }) => {
         {actionsInDropdown.length > 0 && (
           <Dropdown
             onSelect={(e) => {
-              actionsInDropdown.filter(a => e && a.name === e.currentTarget.innerText).forEach(a => a.action());
+              actionsInDropdown.filter(a => e && a.name === e.currentTarget.textContent).forEach(a => a.action());
               setDropdownOpen(false);
             }}
             position="right"


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>

To see the issue, in the "Schedule" screen, shrink Safari's window until the action kebab appears and try to click one of the action in the kebab. This fixes the issue (apparently `innerText` does not work on Safari)  