### PR TITLE
Fix error in multithreaded build caused by missing frontend zip

### DIFF
--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -37,6 +37,17 @@
       <groupId>org.optaweb.employeerostering</groupId>
       <artifactId>optaweb-employee-rostering-backend</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.optaweb.employeerostering</groupId>
+      <artifactId>optaweb-employee-rostering-frontend</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.optaweb.employeerostering</groupId>
+      <artifactId>optaweb-employee-rostering-frontend</artifactId>
+      <type>zip</type>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,13 @@
       <dependency>
         <groupId>org.optaweb.employeerostering</groupId>
         <artifactId>optaweb-employee-rostering-frontend</artifactId>
-        <type>jar</type>
+        <type>zip</type>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.optaweb.employeerostering</groupId>
+        <artifactId>optaweb-employee-rostering-frontend</artifactId>
+        <type>pom</type>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
In a multithreaded build, optaweb-employee-rostering-standalone
is sometimes built before optaweb-employee-rostering-frontend
has finished, causing the resource plugin to error when it
does not find optaweb-employee-rostering-frontend.zip
(only occurs when no version of it exists in .m2). Adding
optaweb-employee-rostering-frontend artifacts as dependencies
seem to fix it.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
