### PR TITLE
Change exit code for cypress tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get autoremove -y >/dev/null 2>&1
           sudo apt-get autoclean -y >/dev/null 2>&1
           sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
-          docker system prune -af
+          docker rmi $(docker image ls -aq) >/dev/null 2>&1
           df -h
       - name: Set up JDK
         uses: actions/setup-java@v1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,50 @@ jobs:
     runs-on: ubuntu-latest
     name: Maven Build
     steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo apt-get remove aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+            clang-6.0 lldb-6.0 lld-6.0 clang-format-6.0 clang-8 lldb-8 lld-8 clang-format-8 \
+            clang-9 lldb-9 lld-9 clangd-9 clang-format-9 dotnet-sdk-3.0 dotnet-sdk-3.1=3.1.101-1 \
+            esl-erlang firefox g++-8 g++-9 gfortran-8 gfortran-9 google-chrome-stable \
+            google-cloud-sdk ghc-8.0.2 ghc-8.2.2 ghc-8.4.4 ghc-8.6.2 ghc-8.6.3 ghc-8.6.4 \
+            ghc-8.6.5 ghc-8.8.1 ghc-8.8.2 ghc-8.8.3 ghc-8.10.1 cabal-install-2.0 cabal-install-2.2 \
+            cabal-install-2.4 cabal-install-3.0 cabal-install-3.2 heroku imagemagick \
+            libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
+            mercurial apt-transport-https mono-complete mysql-client libmysqlclient-dev \
+            mysql-server mssql-tools unixodbc-dev yarn bazel chrpath libssl-dev libxft-dev \
+            libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev php7.1 php7.1-bcmath \
+            php7.1-bz2 php7.1-cgi php7.1-cli php7.1-common php7.1-curl php7.1-dba php7.1-dev \
+            php7.1-enchant php7.1-fpm php7.1-gd php7.1-gmp php7.1-imap php7.1-interbase php7.1-intl \
+            php7.1-json php7.1-ldap php7.1-mbstring php7.1-mcrypt php7.1-mysql php7.1-odbc \
+            php7.1-opcache php7.1-pgsql php7.1-phpdbg php7.1-pspell php7.1-readline php7.1-recode \
+            php7.1-snmp php7.1-soap php7.1-sqlite3 php7.1-sybase php7.1-tidy php7.1-xml \
+            php7.1-xmlrpc php7.1-xsl php7.1-zip php7.2 php7.2-bcmath php7.2-bz2 php7.2-cgi \
+            php7.2-cli php7.2-common php7.2-curl php7.2-dba php7.2-dev php7.2-enchant php7.2-fpm \
+            php7.2-gd php7.2-gmp php7.2-imap php7.2-interbase php7.2-intl php7.2-json php7.2-ldap \
+            php7.2-mbstring php7.2-mysql php7.2-odbc php7.2-opcache php7.2-pgsql php7.2-phpdbg \
+            php7.2-pspell php7.2-readline php7.2-recode php7.2-snmp php7.2-soap php7.2-sqlite3 \
+            php7.2-sybase php7.2-tidy php7.2-xml php7.2-xmlrpc php7.2-xsl php7.2-zip php7.3 \
+            php7.3-bcmath php7.3-bz2 php7.3-cgi php7.3-cli php7.3-common php7.3-curl php7.3-dba \
+            php7.3-dev php7.3-enchant php7.3-fpm php7.3-gd php7.3-gmp php7.3-imap php7.3-interbase \
+            php7.3-intl php7.3-json php7.3-ldap php7.3-mbstring php7.3-mysql php7.3-odbc \
+            php7.3-opcache php7.3-pgsql php7.3-phpdbg php7.3-pspell php7.3-readline php7.3-recode \
+            php7.3-snmp php7.3-soap php7.3-sqlite3 php7.3-sybase php7.3-tidy php7.3-xml \
+            php7.3-xmlrpc php7.3-xsl php7.3-zip php7.4 php7.4-bcmath php7.4-bz2 php7.4-cgi \
+            php7.4-cli php7.4-common php7.4-curl php7.4-dba php7.4-dev php7.4-enchant php7.4-fpm \
+            php7.4-gd php7.4-gmp php7.4-imap php7.4-interbase php7.4-intl php7.4-json php7.4-ldap \
+            php7.4-mbstring php7.4-mysql php7.4-odbc php7.4-opcache php7.4-pgsql php7.4-phpdbg \
+            php7.4-pspell php7.4-readline php7.4-snmp php7.4-soap php7.4-sqlite3 php7.4-sybase \
+            php7.4-tidy php7.4-xml php7.4-xmlrpc php7.4-xsl php7.4-zip php-amqp php-apcu \
+            php-igbinary php-memcache php-memcached php-mongodb php-redis php-xdebug \
+            php-zmq snmp pollinate libpq-dev postgresql-client powershell ruby-full \
+            sphinxsearch subversion mongodb-org -yq >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
+          docker system prune -af
+          df -h
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,18 +66,8 @@ jobs:
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v1.4
+        uses: kiegroup/github-action-build-chain@v2.1
         with:
-          parent-dependencies: 'kie-docs'
-          child-dependencies: 'optaweb-vehicle-routing'
-          build-command: 'mvn -e -nsu -Dfull -Pwildfly install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true'
-          build-command-upstream: |
-            mvn -e --builder smart -T1C install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
-            rm -rf ./*
-          workflow-file-name: "pull_request.yml"
-          archive-artifacts-path: |
-            **/cypress/screenshots/**
-            **/cypress/videos/**
+          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-                                                                                                              

--- a/optaweb-employee-rostering-frontend/cypress.json
+++ b/optaweb-employee-rostering-frontend/cypress.json
@@ -1,5 +1,5 @@
 {
-    "baseUrl": "http://localhost:3000",
+    "baseUrl": "http://localhost:8180",
     "reporter": "junit",
     "reporterOptions": {
         "mochaFile": "target/test-reports/TEST-cypress.xml",

--- a/optaweb-employee-rostering-frontend/cypress.json
+++ b/optaweb-employee-rostering-frontend/cypress.json
@@ -1,5 +1,5 @@
 {
-    "baseUrl": "http://localhost:8180",
+    "baseUrl": "http://localhost:3000",
     "reporter": "junit",
     "reporterOptions": {
         "mochaFile": "target/test-reports/TEST-cypress.xml",

--- a/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
+++ b/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
@@ -66,10 +66,6 @@ describe('A new tenant can be created, who can have their own employees, spots, 
 
   beforeEach(() => {
     cy.wait(3000);// Wait for all data from last test/start to finish loading
-    cy.get('[data-cy=settings]').click();
-    cy.get('[data-cy=reset-application]').click();
-    cy.get('[data-cy=confirm]').click();
-    closeAlerts();
   });
 
   it('basic tenant workflow', () => {

--- a/optaweb-employee-rostering-frontend/cypress/test_runners/nodeTestRunner.js
+++ b/optaweb-employee-rostering-frontend/cypress/test_runners/nodeTestRunner.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const cypress = require('cypress');
+
+cypress.run({
+  spec: './cypress/integration/*.js',
+})
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });

--- a/optaweb-employee-rostering-frontend/cypress/test_runners/nodeTestRunner.js
+++ b/optaweb-employee-rostering-frontend/cypress/test_runners/nodeTestRunner.js
@@ -19,13 +19,12 @@ const cypress = require('cypress');
 
 async function cypressRunWithCiArgs() {
   const runOptions = await cypress.cli.parseRunArguments(process.argv.slice(2));
-  const results = await cypress.run(runOptions)
+  await cypress.run(runOptions)
     .then(() => {
       process.exit(0);
-     })
-     .catch((err) => {
-      console.error(err.message);
+    })
+    .catch(() => {
       process.exit(1);
-     });
+    });
 }
 cypressRunWithCiArgs();

--- a/optaweb-employee-rostering-frontend/cypress/test_runners/nodeTestRunner.js
+++ b/optaweb-employee-rostering-frontend/cypress/test_runners/nodeTestRunner.js
@@ -17,13 +17,15 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const cypress = require('cypress');
 
-cypress.run({
-  spec: './cypress/integration/*.js',
-})
-  .then(() => {
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error(err.message);
-    process.exit(1);
-  });
+async function cypressRunWithCiArgs() {
+  const runOptions = await cypress.cli.parseRunArguments(process.argv.slice(2));
+  const results = await cypress.run(runOptions)
+    .then(() => {
+      process.exit(0);
+     })
+     .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+     });
+}
+cypressRunWithCiArgs();

--- a/optaweb-employee-rostering-frontend/cypress/tsconfig.json
+++ b/optaweb-employee-rostering-frontend/cypress/tsconfig.json
@@ -20,7 +20,7 @@
     "skipLibCheck": true
   },
   "include": [
-    "fixtures", "integration", "plugins"
+    "fixtures", "integration", "plugins", "test_runners"
   ],
   "exclude": [
     "build",

--- a/optaweb-employee-rostering-standalone/README.adoc
+++ b/optaweb-employee-rostering-standalone/README.adoc
@@ -3,7 +3,7 @@
 
 == Build and Run with Maven
 
-In the project backend directory, run the following command:
+Build the project with maven in the project’s root directory:
 
 ----
 mvn clean install -DskipTests -DskipITs
@@ -15,34 +15,44 @@ It packs the standalone jar from the dependencies:
 - optaweb-employee-rostering-frontend
 
 ----
-java -jar ./target/optaweb-employee-rostering-standalone-*-exec.jar
+java -jar ./optaweb-employee-rostering-standalone/target/optaweb-employee-rostering-standalone-*-exec.jar
 ----
 
 Runs the app. Open http://localhost:8080 to view
 it in the browser.
 
 == Run integration tests
-
+When you build optaweb-employee-rostering, you can run integration tests.
+----
+cd optaweb-employee-rostering-standalone
+----
 ----
 mvn clean install -Pintegration-tests -Dcontainer.runtime={container.runtime}
 ----
+What it does:
 
-1. Run repacks new standalone jar and launches application on http://localhost:8180.
-2. In addition, runs cypress tests in {container.runtime} docker by default.
+1. Repacks new standalone jar and launches it on http://localhost:8180.
+2. Runs cypress tests in {container.runtime} docker by default.
 
 == To run integration tests separately
 
 Launch standalone application
 
 ----
-java -jar ./target/optaweb-employee-rostering-standalone-*-exec.jar
+java -jar ./optaweb-employee-rostering-standalone//target/optaweb-employee-rostering-standalone-*-exec.jar
 ----
 
-Run cypress tests in a container
+#### Run cypress tests within a container
 
 [source,shell]
 ----
 podman run --network=host -v {project.parent.basedir}/{frontend.project.name}:/e2e:Z
 -w /e2e --entrypoint node cypress/included:{version.cypress.docker}
-./cypress/test_runners/nodeTestRunner.js --config baseUrl=http://localhost:8080
+./cypress/test_runners/nodeTestRunner.js cypress run --config baseUrl=http://localhost:{application.port}
+----
+
+#### Run cypress tests locally
+
+----
+node ./cypress/test_runners/nodeTestRunner.js cypress run --config baseUrl=http://localhost:{application.port}
 ----

--- a/optaweb-employee-rostering-standalone/README.adoc
+++ b/optaweb-employee-rostering-standalone/README.adoc
@@ -1,0 +1,48 @@
+[[optaweb-employee-rostering-standalone]]
+= OptaWeb Employee Rostering Standalone
+
+== Build and Run with Maven
+
+In the project backend directory, run the following command:
+
+----
+mvn clean install -DskipTests -DskipITs
+----
+
+It packs the standalone jar from the dependencies:
+
+- optaweb-employee-rostering-backend
+- optaweb-employee-rostering-frontend
+
+----
+java -jar ./target/optaweb-employee-rostering-standalone-*-exec.jar
+----
+
+Runs the app. Open http://localhost:8080 to view
+it in the browser.
+
+== Run integration tests
+
+----
+mvn clean install -Pintegration-tests -Dcontainer.runtime={container.runtime}
+----
+
+1. Run repacks new standalone jar and launches application on http://localhost:8180.
+2. In addition, runs cypress tests in {container.runtime} docker by default.
+
+== To run integration tests separately
+
+Launch standalone application
+
+----
+java -jar ./target/optaweb-employee-rostering-standalone-*-exec.jar
+----
+
+Run cypress tests in a container
+
+[source,shell]
+----
+podman run --network=host -v {project.parent.basedir}/{frontend.project.name}:/e2e:Z
+-w /e2e --entrypoint node cypress/included:{version.cypress.docker}
+./cypress/test_runners/nodeTestRunner.js --config baseUrl=http://localhost:8080
+----

--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -191,11 +191,9 @@
                     <argument>-w</argument>
                     <argument>/e2e</argument>
                     <argument>--entrypoint</argument>
-                    <argument>cypress</argument>
+                    <argument>node</argument>
                     <argument>cypress/included:${version.cypress.docker}</argument>
-                    <argument>run</argument> <!-- Executing cypress:run -->
-                    <argument>--project</argument>
-                    <argument>.</argument>
+                    <argument>./cypress/test_runners/nodeTestRunner.js</argument> <!--Run all integration specs in node-->
                     <argument>--config</argument>
                     <argument>baseUrl=http://localhost:${application.port}</argument>
                   </arguments>

--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -194,6 +194,8 @@
                     <argument>node</argument>
                     <argument>cypress/included:${version.cypress.docker}</argument>
                     <argument>./cypress/test_runners/nodeTestRunner.js</argument> <!--Run all integration specs in node-->
+                    <argument>cypress</argument>
+                    <argument>run</argument>
                     <argument>--config</argument>
                     <argument>baseUrl=http://localhost:${application.port}</argument>
                   </arguments>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

[PLANNER-2188](https://issues.redhat.com/browse/PLANNER-2188)

### Automation configuration
Don't fail the build if there are some unstable/failed UI tests.

By default in case of test failure `cypress run` finishes with 1 ... n code (n - number of failing tests)
Then this result propagates to the podman and to the exec-maven-plugin and to the Jenkins

What we need is
If Cypress test failed then mark build successful && make reports => Jenkins will interpret this as unstable
If Cypress was unable to run tests || failed to execute || podman failed then mark build as failed => Jenkins will mark build as failed

I made a small wrapper for the tests so it is possible to: 
- manage exit code
- use more than one test

The test runner is nothing but wrapper to run tests in node to customize exit code

Alternatives:
- It is possible to ignore any podman failures by using <successCodes> since podman exits with 125,126,127 codes,
but this failure could be never recognized later since build would be green always
- It is possible to ignore cypress failure as well in nodeTestRunner but the problem is the same as above  

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
