### PR TITLE
[master] BXMSPROD-1062 kiegroup/github-action-build-chain updated

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,8 +92,8 @@ jobs:
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.1
+        uses: kiegroup/github-action-build-chain@v2.2
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/master/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1062

related PRs:
* https://github.com/kiegroup/kie-soup/pull/164
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/483
* https://github.com/kiegroup/drools/pull/3216
* https://github.com/kiegroup/optaplanner/pull/1013
* https://github.com/kiegroup/jbpm/pull/1795
* https://github.com/kiegroup/kie-jpmml-integration/pull/47
* https://github.com/kiegroup/droolsjbpm-integration/pull/2309
* https://github.com/kiegroup/openshift-drools-hacep/pull/104
* https://github.com/kiegroup/droolsjbpm-tools/pull/123
* https://github.com/kiegroup/lienzo-core/pull/139
* https://github.com/kiegroup/lienzo-tests/pull/112
* https://github.com/kiegroup/appformer/pull/1074
* https://github.com/kiegroup/kie-uberfire-extensions/pull/110
* https://github.com/kiegroup/kie-wb-playground/pull/101
* https://github.com/kiegroup/kie-wb-common/pull/3476
* https://github.com/kiegroup/drools-wb/pull/1438
* https://github.com/kiegroup/optaplanner-wb/pull/386
* https://github.com/kiegroup/jbpm-designer/pull/896
* https://github.com/kiegroup/jbpm-work-items/pull/166
* https://github.com/kiegroup/jbpm-wb/pull/1470
* https://github.com/kiegroup/kie-docs/pull/3051
* https://github.com/kiegroup/optaweb-employee-rostering/pull/523
* https://github.com/kiegroup/optaweb-employee-rostering/pull/527
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/395
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/405
* https://github.com/kiegroup/kie-wb-distributions/pull/1070