### PR TITLE
PLANNER-2102: Migrate OptaWeb Employee Rostering to JUnit 5

### DIFF
--- a/optaweb-employee-rostering-backend/pom.xml
+++ b/optaweb-employee-rostering-backend/pom.xml
@@ -137,7 +137,7 @@
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -147,6 +147,10 @@
           <groupId>jakarta.xml.bind</groupId>
           <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     
@@ -155,17 +159,28 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
 
   </dependencies>

--- a/optaweb-employee-rostering-backend/pom.xml
+++ b/optaweb-employee-rostering-backend/pom.xml
@@ -181,6 +181,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/admin/AdminRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/admin/AdminRestControllerTest.java
@@ -18,17 +18,14 @@ package org.optaweb.employeerostering.admin;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class AdminRestControllerTest {

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractRestControllerTest.java
@@ -20,10 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
@@ -35,9 +34,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class ContractRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -69,12 +66,12 @@ public class ContractRestControllerTest extends AbstractEntityRequireTenantRestS
         return restTemplate.postForEntity(contractPathURI + "update", contractView, Contract.class, tenantId);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractServiceTest.java
@@ -16,15 +16,13 @@
 
 package org.optaweb.employeerostering.contract;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
@@ -36,7 +34,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -44,7 +41,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureTestDatabase
 @AutoConfigureMockMvc
@@ -59,12 +55,12 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
     @Autowired
     private ContractService contractService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeRestControllerTest.java
@@ -24,10 +24,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.employee.Employee;
@@ -43,9 +42,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class EmployeeRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -109,12 +106,12 @@ public class EmployeeRestControllerTest extends AbstractEntityRequireTenantRestS
                 EmployeeAvailabilityView.class, tenantId);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeServiceTest.java
@@ -16,9 +16,8 @@
 
 package org.optaweb.employeerostering.employee;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,10 +34,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
@@ -58,7 +56,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -66,7 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureTestDatabase
 @AutoConfigureMockMvc
@@ -97,12 +93,12 @@ public class EmployeeServiceTest extends AbstractEntityRequireTenantRestServiceT
         return contractService.createContract(tenantId, contractView);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }
@@ -791,19 +787,15 @@ public class EmployeeServiceTest extends AbstractEntityRequireTenantRestServiceT
                     .filter(e -> e.getName().equals(expected.getName())).findAny();
             if (maybeActual.isPresent()) {
                 Employee actual = maybeActual.get();
-                assertEquals("Wrong contract for " + expected.getName(),
-                        expected.getContract(), actual.getContract());
-                assertEquals("Wrong tenant id for " + expected.getName(),
-                        expected.getTenantId(), actual.getTenantId());
-                assertEquals("Wrong number of skills for " + expected.getName(),
-                        expected.getSkillProficiencySet().size(), actual.getSkillProficiencySet().size());
+                assertThat(actual.getContract()).withFailMessage("Wrong contract for " + expected.getName())
+                        .isEqualTo(expected.getContract());
+                assertThat(actual.getTenantId()).withFailMessage("Wrong tenant id for " + expected.getName())
+                        .isEqualTo(expected.getTenantId());
+                assertThat(actual.getSkillProficiencySet()).withFailMessage("Wrong number of skills for " + expected.getName())
+                        .hasSize(expected.getSkillProficiencySet().size());
 
-                expected.getSkillProficiencySet().forEach(skill -> assertTrue("Missing skill " + skill.getName() +
-                        " for employee " +
-                        expected.getName(),
-                        actual.getSkillProficiencySet().stream()
-                                .anyMatch(s -> s.getName()
-                                        .equals(skill.getName()))));
+                assertThat(actual.getSkillProficiencySet()).allMatch(skill -> expected.getSkillProficiencySet().stream()
+                        .anyMatch(expectedSkill -> skill.getName().equals(expectedSkill.getName())));
             } else {
                 fail("Expected an employee with name (" + expected.getName() + "), but no such employee was found.");
             }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/exception/ExceptionDataMapperTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/exception/ExceptionDataMapperTest.java
@@ -16,12 +16,12 @@
 
 package org.optaweb.employeerostering.exception;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.RollbackException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.ExceptionDataMapper;
 import org.optaweb.employeerostering.domain.exception.ConstraintViolatedException;
 

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/generator/RosterGeneratorTest.java
@@ -20,10 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.employee.Employee;
 import org.optaweb.employeerostering.domain.rotation.view.TimeBucketView;
@@ -40,9 +39,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class RosterGeneratorTest {
@@ -105,12 +102,12 @@ public class RosterGeneratorTest {
                 });
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         tenantId = rosterGenerator.generateRoster(2, 7).getTenantId();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         restTemplate.postForEntity(tenantPathURI + "remove/" + tenantId, null, Void.class);
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
@@ -18,7 +18,7 @@ package org.optaweb.employeerostering.roster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -37,9 +37,8 @@ import java.util.stream.Collectors;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
@@ -65,11 +64,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class RosterRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -270,7 +267,7 @@ public class RosterRestControllerTest extends AbstractEntityRequireTenantRestSer
         employeeAvailabilityViewList = Arrays.asList(employeeAvailabilityA);
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/rotation/RotationRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/rotation/RotationRestControllerTest.java
@@ -22,10 +22,9 @@ import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.rotation.TimeBucket;
 import org.optaweb.employeerostering.domain.rotation.view.TimeBucketView;
@@ -40,9 +39,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class RotationRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -82,12 +79,12 @@ public class RotationRestControllerTest extends AbstractEntityRequireTenantRestS
         return restTemplate.postForEntity(spotPathURI + "add", spotView, Spot.class, tenantId);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/rotation/RotationServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/rotation/RotationServiceTest.java
@@ -23,10 +23,9 @@ import java.time.LocalTime;
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.rotation.TimeBucket;
 import org.optaweb.employeerostering.domain.rotation.view.TimeBucketView;
@@ -42,7 +41,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -50,7 +48,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureTestDatabase
 @AutoConfigureMockMvc
@@ -76,12 +73,12 @@ public class RotationServiceTest extends AbstractEntityRequireTenantRestServiceT
         return spotService.createSpot(tenantId, spotView);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftRestControllerTest.java
@@ -22,10 +22,9 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.employee.Employee;
@@ -41,9 +40,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class ShiftRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -90,12 +87,12 @@ public class ShiftRestControllerTest extends AbstractEntityRequireTenantRestServ
         return restTemplate.postForEntity(spotPathURI + "add", spotView, Spot.class, tenantId);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/shift/ShiftServiceTest.java
@@ -22,10 +22,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import java.util.Collections;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.contract.Contract;
 import org.optaweb.employeerostering.domain.contract.view.ContractView;
@@ -45,7 +44,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -53,7 +51,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureTestDatabase
 @AutoConfigureMockMvc
@@ -92,12 +89,12 @@ public class ShiftServiceTest extends AbstractEntityRequireTenantRestServiceTest
         return employeeService.createEmployee(tenantId, employeeView);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillRestControllerTest.java
@@ -20,10 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.skill.view.SkillView;
@@ -35,9 +34,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class SkillRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -69,12 +66,12 @@ public class SkillRestControllerTest extends AbstractEntityRequireTenantRestServ
         return restTemplate.postForEntity(skillPathURI + "update", skillView, Skill.class, tenantId);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/skill/SkillServiceTest.java
@@ -19,10 +19,9 @@ package org.optaweb.employeerostering.skill;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.skill.view.SkillView;
@@ -34,7 +33,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -42,7 +40,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureTestDatabase
 @AutoConfigureMockMvc
@@ -57,12 +54,12 @@ public class SkillServiceTest extends AbstractEntityRequireTenantRestServiceTest
     @Autowired
     private SkillService skillService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/AbstractSolverTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/AbstractSolverTest.java
@@ -17,9 +17,7 @@
 package org.optaweb.employeerostering.solver;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -54,8 +52,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.persistence.EntityManager;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
@@ -111,7 +110,8 @@ public abstract class AbstractSolverTest {
 
     // A solver "integration" test that verify that our constraints can create a feasible
     // solution on our demo data set
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testFeasibleSolution() {
         Solver<Roster> solver = getSolverFactory().buildSolver();
 
@@ -127,7 +127,8 @@ public abstract class AbstractSolverTest {
     }
 
     // A solver "integration" test that verify it moves only draft shifts
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testMoveOnlyDraftShifts() {
         Solver<Roster> solver = getSolverFactory().buildSolver();
 
@@ -244,14 +245,16 @@ public abstract class AbstractSolverTest {
         constraint.verifyNumOfInstances(scoreVerifier, roster, 60);
     }
 
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testContractConstraints() {
         for (ContractField field : ContractField.values()) {
             testContractConstraint(field);
         }
     }
 
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testRequiredSkillForShiftConstraint() {
         HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
 
@@ -382,14 +385,16 @@ public abstract class AbstractSolverTest {
         constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
     }
 
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testEmployeeAvailabilityConstraints() {
         for (EmployeeAvailabilityState state : EmployeeAvailabilityState.values()) {
             testAvailabilityConstraint(state);
         }
     }
 
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testNoMoreThan2ConsecutiveShifts() {
         HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
 
@@ -447,7 +452,8 @@ public abstract class AbstractSolverTest {
         constraint.verifyNumOfInstances(scoreVerifier, roster, 60);
     }
 
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testBreaksBetweenConsecutiveShiftsAtLeast10Hours() {
         HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
 
@@ -515,7 +521,8 @@ public abstract class AbstractSolverTest {
         constraint.verifyNumOfInstances(scoreVerifier, roster, 540);
     }
 
-    @Test(timeout = 600000)
+    @Test
+    @Timeout(600000)
     public void testAssignEveryShift() {
         HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
 
@@ -570,8 +577,9 @@ public abstract class AbstractSolverTest {
         constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
     }
 
-    @Ignore("Disabled as in this new world, predictability of schedules does not matter.")
-    @Test(timeout = 600000)
+    @Disabled("Disabled as in this new world, predictability of schedules does not matter.")
+    @Test
+    @Timeout(600000)
     public void testEmployeeIsNotRotationEmployeeConstraint() {
         HardMediumSoftLongScoreVerifier<Roster> scoreVerifier = getScoreVerifier();
 
@@ -662,6 +670,10 @@ public abstract class AbstractSolverTest {
         return ROSTER_CONSTRAINT_CONFIGURATION;
     }
 
+    // In regards to the FIXME below, this test is for both Drools and Constraint Streams,
+    // and Drools doesn't have a constraintVerifier equivalent yet, meaning we need to
+    // use scoreVerifier, which does not have a getNumberOfInstances, so we need the
+    // weight to implement that functionality
     // FIXME Constraint name and weight are already coupled in RosterConstraintConfiguration.
     //  This information should be read from OptaPlanner, not re-assembled here.
     private enum Constraints {

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/ConstraintProviderSolverTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/ConstraintProviderSolverTest.java
@@ -16,7 +16,6 @@
 
 package org.optaweb.employeerostering.solver;
 
-import org.junit.runner.RunWith;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
@@ -26,9 +25,7 @@ import org.optaweb.employeerostering.service.solver.EmployeeRosteringConstraintP
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class ConstraintProviderSolverTest extends AbstractSolverTest {

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/DroolsSolverTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/DroolsSolverTest.java
@@ -16,7 +16,6 @@
 
 package org.optaweb.employeerostering.solver;
 
-import org.junit.runner.RunWith;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
@@ -24,9 +23,7 @@ import org.optaweb.employeerostering.domain.roster.Roster;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class DroolsSolverTest extends AbstractSolverTest {

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotRestControllerTest.java
@@ -21,10 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.spot.Spot;
 import org.optaweb.employeerostering.domain.spot.view.SpotView;
@@ -36,9 +35,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class SpotRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -70,12 +67,12 @@ public class SpotRestControllerTest extends AbstractEntityRequireTenantRestServi
         return restTemplate.postForEntity(spotPathURI + "update", spotView, Spot.class, tenantId);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/spot/SpotServiceTest.java
@@ -23,10 +23,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.skill.Skill;
 import org.optaweb.employeerostering.domain.skill.view.SkillView;
@@ -41,7 +40,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -49,7 +47,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureTestDatabase
 @AutoConfigureMockMvc
@@ -72,12 +69,12 @@ public class SpotServiceTest extends AbstractEntityRequireTenantRestServiceTest 
         return skillService.createSkill(tenantId, skillView);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/tenant/TenantRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/tenant/TenantRestControllerTest.java
@@ -23,10 +23,9 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaweb.employeerostering.AbstractEntityRequireTenantRestServiceTest;
 import org.optaweb.employeerostering.domain.roster.view.RosterStateView;
@@ -39,9 +38,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureTestDatabase
 public class TenantRestControllerTest extends AbstractEntityRequireTenantRestServiceTest {
@@ -78,12 +75,12 @@ public class TenantRestControllerTest extends AbstractEntityRequireTenantRestSer
         return restTemplate.getForEntity(tenantPathURI + "supported/timezones", List.class);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         createTestTenant();
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         deleteTestTenant();
     }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/util/HierarchyTreeTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/util/HierarchyTreeTest.java
@@ -16,18 +16,18 @@
 
 package org.optaweb.employeerostering.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HierarchyTreeTest {
 
     private HierarchyTree<Integer, String> tested;
 
-    @Before
+    @BeforeEach
     public void setup() {
         // tested is the divisibility Hierarchy Tree;
         // a is above b iff a divides b

--- a/optaweb-employee-rostering-benchmark/pom.xml
+++ b/optaweb-employee-rostering-benchmark/pom.xml
@@ -96,24 +96,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/optaweb-employee-rostering-benchmark/pom.xml
+++ b/optaweb-employee-rostering-benchmark/pom.xml
@@ -90,6 +90,10 @@
           <groupId>jakarta.xml.bind</groupId>
           <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     
@@ -103,11 +107,23 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-    
+
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/optaweb-employee-rostering-benchmark/src/test/java/org/optaweb/employeerostering/BenchmarkTest.java
+++ b/optaweb-employee-rostering-benchmark/src/test/java/org/optaweb/employeerostering/BenchmarkTest.java
@@ -16,8 +16,6 @@
 
 package org.optaweb.employeerostering;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
@@ -27,19 +25,17 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = OptaWebEmployeeRosteringBenchmarkApplication.class)
 public class BenchmarkTest {
 
     private static Set<File> oldBenchmarkFilesInDirectory = Collections.emptySet();
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         Path benchmarkLocalDirectory = Paths.get("local/benchmarkReport");
         if (benchmarkLocalDirectory.toFile().exists()) {
@@ -53,6 +49,6 @@ public class BenchmarkTest {
                 .filter(f -> !oldBenchmarkFilesInDirectory.contains(f))
                 .findAny()
                 .orElseThrow(() -> new FileNotFoundException("No benchmark report found"));
-        assertTrue(benchmarkReport.exists());
+        Assertions.assertTrue(benchmarkReport.exists());
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2102

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
