### PR TITLE
PLANNER-2103: Replace all JUnit Assertions with AssertJ

### DIFF
--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/contract/ContractServiceTest.java
@@ -16,7 +16,7 @@
 
 package org.optaweb.employeerostering.contract;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -309,11 +309,11 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
     @Test
     public void getOrCreateDefaultContractNotExistsTest() {
         Contract contract = contractService.getOrCreateDefaultContract(TENANT_ID);
-        assertEquals(contract.getName(), "Default Contract");
-        assertNull(contract.getMaximumMinutesPerDay());
-        assertNull(contract.getMaximumMinutesPerWeek());
-        assertNull(contract.getMaximumMinutesPerMonth());
-        assertNull(contract.getMaximumMinutesPerYear());
+        assertThat(contract.getName()).isEqualTo("Default Contract");
+        assertThat(contract.getMaximumMinutesPerDay()).isNull();
+        assertThat(contract.getMaximumMinutesPerWeek()).isNull();
+        assertThat(contract.getMaximumMinutesPerMonth()).isNull();
+        assertThat(contract.getMaximumMinutesPerYear()).isNull();
     }
 
     @Test
@@ -326,6 +326,6 @@ public class ContractServiceTest extends AbstractEntityRequireTenantRestServiceT
         Contract contract = contractService.createContract(TENANT_ID, contractView);
         Contract defaultContract = contractService.getOrCreateDefaultContract(TENANT_ID);
 
-        assertEquals(contract, defaultContract);
+        assertThat(defaultContract).isEqualTo(contract);
     }
 }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeServiceTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/employee/EmployeeServiceTest.java
@@ -16,8 +16,7 @@
 
 package org.optaweb.employeerostering.employee;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/exception/ExceptionDataMapperTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/exception/ExceptionDataMapperTest.java
@@ -16,7 +16,7 @@
 
 package org.optaweb.employeerostering.exception;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.RollbackException;
@@ -32,19 +32,19 @@ public class ExceptionDataMapperTest {
     @Test
     public void testGetExceptionDataForExceptionClass() {
         tested = new ExceptionDataMapper();
-        assertEquals(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION,
-                tested.getExceptionDataForExceptionClass(Throwable.class));
-        assertEquals(ExceptionDataMapper.ExceptionData.ENTITY_CONSTRAINT_VIOLATION,
-                tested.getExceptionDataForExceptionClass(ConstraintViolatedException.class));
-        assertEquals(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION,
-                tested.getExceptionDataForExceptionClass(IllegalStateException.class));
-        assertEquals(ExceptionDataMapper.ExceptionData.ILLEGAL_ARGUMENT,
-                tested.getExceptionDataForExceptionClass(IllegalArgumentException.class));
-        assertEquals(ExceptionDataMapper.ExceptionData.NULL_POINTER,
-                tested.getExceptionDataForExceptionClass(NullPointerException.class));
-        assertEquals(ExceptionDataMapper.ExceptionData.ENTITY_NOT_FOUND,
-                tested.getExceptionDataForExceptionClass(EntityNotFoundException.class));
-        assertEquals(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION,
-                tested.getExceptionDataForExceptionClass(RollbackException.class));
+        assertThat(tested.getExceptionDataForExceptionClass(Throwable.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION);
+        assertThat(tested.getExceptionDataForExceptionClass(ConstraintViolatedException.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.ENTITY_CONSTRAINT_VIOLATION);
+        assertThat(tested.getExceptionDataForExceptionClass(IllegalStateException.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION);
+        assertThat(tested.getExceptionDataForExceptionClass(IllegalArgumentException.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.ILLEGAL_ARGUMENT);
+        assertThat(tested.getExceptionDataForExceptionClass(NullPointerException.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.NULL_POINTER);
+        assertThat(tested.getExceptionDataForExceptionClass(EntityNotFoundException.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.ENTITY_NOT_FOUND);
+        assertThat(tested.getExceptionDataForExceptionClass(RollbackException.class))
+                .isEqualTo(ExceptionDataMapper.ExceptionData.GENERIC_EXCEPTION);
     }
 }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/roster/RosterRestControllerTest.java
@@ -16,9 +16,7 @@
 
 package org.optaweb.employeerostering.roster;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/AbstractSolverTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/AbstractSolverTest.java
@@ -16,8 +16,7 @@
 
 package org.optaweb.employeerostering.solver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -52,7 +51,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.persistence.EntityManager;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
@@ -119,11 +117,11 @@ public abstract class AbstractSolverTest {
         Roster roster = rosterGenerator.generateRoster(10, 7);
 
         roster = solver.solve(roster);
-        assertNotNull(roster.getScore());
+        assertThat(roster.getScore()).isNotNull();
         // Due to overconstrained planning, the score is always feasible
-        assertTrue(roster.getScore().isFeasible());
-        assertFalse(roster.getShiftList().isEmpty());
-        assertTrue(roster.getShiftList().stream().anyMatch(s -> s.getEmployee() != null));
+        assertThat(roster.getScore().isFeasible()).isTrue();
+        assertThat(roster.getShiftList()).isNotEmpty();
+        assertThat(roster.getShiftList()).anyMatch(s -> s.getEmployee() != null);
     }
 
     // A solver "integration" test that verify it moves only draft shifts
@@ -176,12 +174,12 @@ public abstract class AbstractSolverTest {
         roster.setShiftList(shiftList);
 
         roster = solver.solve(roster);
-        assertTrue(roster.getShiftList().stream()
-                .filter(s -> !rosterState.isDraft(s))
-                .allMatch(s -> s.getEmployee().equals(employeeA)));
-        assertTrue(roster.getShiftList().stream()
-                .filter(rosterState::isDraft)
-                .allMatch(s -> s.getEmployee().equals(employeeB)));
+        assertThat(roster.getShiftList())
+                .filteredOn(s -> !rosterState.isDraft(s))
+                .allMatch(s -> s.getEmployee().equals(employeeA));
+        assertThat(roster.getShiftList())
+                .filteredOn(rosterState::isDraft)
+                .allMatch(s -> s.getEmployee().equals(employeeB));
     }
 
     private void testContractConstraint(ContractField contractField) {
@@ -577,7 +575,6 @@ public abstract class AbstractSolverTest {
         constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
     }
 
-    @Disabled("Disabled as in this new world, predictability of schedules does not matter.")
     @Test
     @Timeout(600000)
     public void testEmployeeIsNotRotationEmployeeConstraint() {
@@ -617,7 +614,7 @@ public abstract class AbstractSolverTest {
         roster.setShiftList(Collections.singletonList(shift));
 
         final Constraints constraint = Constraints.EMPLOYEE_IS_NOT_ROTATION_EMPLOYEE;
-        constraint.verifyNumOfInstances(scoreVerifier, roster, 1);
+        constraint.verifyNumOfInstances(scoreVerifier, roster, (int) shift.getLengthInMinutes());
 
         shift.setEmployee(rotationEmployee);
         constraint.verifyNumOfInstances(scoreVerifier, roster, 0);

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/util/HierarchyTreeTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/util/HierarchyTreeTest.java
@@ -16,9 +16,7 @@
 
 package org.optaweb.employeerostering.util;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Optional;
+import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,33 +44,33 @@ public class HierarchyTreeTest {
 
     @Test
     public void testPutInHierarchyAndGetHierarchyClassValue() {
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(4));
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(6));
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(3));
+        assertThat(tested.getHierarchyClassValue(2)).isEmpty();
+        assertThat(tested.getHierarchyClassValue(4)).isEmpty();
+        assertThat(tested.getHierarchyClassValue(6)).isEmpty();
+        assertThat(tested.getHierarchyClassValue(3)).isEmpty();
 
         tested.putInHierarchy(4, "4");
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
-        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
-        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(12));
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(3));
+        assertThat(tested.getHierarchyClassValue(2)).isEmpty();
+        assertThat(tested.getHierarchyClassValue(4)).hasValue("4");
+        assertThat(tested.getHierarchyClassValue(12)).hasValue("4");
+        assertThat(tested.getHierarchyClassValue(3)).isEmpty();
 
         tested.putInHierarchy(12, "12");
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
-        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
-        assertEquals(Optional.of("12"), tested.getHierarchyClassValue(12));
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(3));
+        assertThat(tested.getHierarchyClassValue(2)).isEmpty();
+        assertThat(tested.getHierarchyClassValue(4)).hasValue("4");
+        assertThat(tested.getHierarchyClassValue(12)).hasValue("12");
+        assertThat(tested.getHierarchyClassValue(3)).isEmpty();
 
         tested.putInHierarchy(3, "3");
-        assertEquals(Optional.empty(), tested.getHierarchyClassValue(2));
-        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
-        assertEquals(Optional.of("12"), tested.getHierarchyClassValue(12));
-        assertEquals(Optional.of("3"), tested.getHierarchyClassValue(3));
+        assertThat(tested.getHierarchyClassValue(2)).isEmpty();
+        assertThat(tested.getHierarchyClassValue(4)).hasValue("4");
+        assertThat(tested.getHierarchyClassValue(12)).hasValue("12");
+        assertThat(tested.getHierarchyClassValue(3)).hasValue("3");
 
         tested.putInHierarchy(2, "2");
-        assertEquals(Optional.of("2"), tested.getHierarchyClassValue(2));
-        assertEquals(Optional.of("4"), tested.getHierarchyClassValue(4));
-        assertEquals(Optional.of("12"), tested.getHierarchyClassValue(12));
-        assertEquals(Optional.of("3"), tested.getHierarchyClassValue(3));
+        assertThat(tested.getHierarchyClassValue(2)).hasValue("2");
+        assertThat(tested.getHierarchyClassValue(4)).hasValue("4");
+        assertThat(tested.getHierarchyClassValue(12)).hasValue("12");
+        assertThat(tested.getHierarchyClassValue(3)).hasValue("3");
     }
 }

--- a/optaweb-employee-rostering-benchmark/src/test/java/org/optaweb/employeerostering/BenchmarkTest.java
+++ b/optaweb-employee-rostering-benchmark/src/test/java/org/optaweb/employeerostering/BenchmarkTest.java
@@ -16,6 +16,8 @@
 
 package org.optaweb.employeerostering;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
@@ -25,7 +27,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,6 +50,8 @@ public class BenchmarkTest {
                 .filter(f -> !oldBenchmarkFilesInDirectory.contains(f))
                 .findAny()
                 .orElseThrow(() -> new FileNotFoundException("No benchmark report found"));
-        Assertions.assertTrue(benchmarkReport.exists());
+        assertThat(benchmarkReport.exists())
+                .withFailMessage("No Benchmark Report at " + benchmarkReport.getAbsolutePath())
+                .isTrue();
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->
https://issues.redhat.com/browse/PLANNER-2103

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
