### PR TITLE
Use @ManyToMany instead of @OneToMany in TimeBucket additionalSkillSet

### DIFF
--- a/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/rotation/TimeBucket.java
+++ b/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/rotation/TimeBucket.java
@@ -31,10 +31,13 @@ import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.validation.constraints.NotNull;
 
 import org.optaweb.employeerostering.domain.common.AbstractPersistable;
 import org.optaweb.employeerostering.domain.shift.Shift;
@@ -49,7 +52,11 @@ public class TimeBucket extends AbstractPersistable {
     @ManyToOne
     private Spot spot;
 
-    @OneToMany
+    @NotNull
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(name = "TimeBucketAdditionalSkillSet",
+            joinColumns = @JoinColumn(name = "timebucketId", referencedColumnName = "id"),
+            inverseJoinColumns = @JoinColumn(name = "skillId", referencedColumnName = "id"))
     private Set<Skill> additionalSkillSet;
 
     @ElementCollection


### PR DESCRIPTION
Using `@OneToMany` adds an additional constraint of no two time buckets
sharing any additional skills, which is unwarranted. The relation
should be `@ManyToMany` instead.

Fixes #541.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
