### PR TITLE
Pass local date as string to backend instead of raw Javascript Date

### DIFF
--- a/optaweb-employee-rostering-frontend/src/store/tenant/operations.ts
+++ b/optaweb-employee-rostering-frontend/src/store/tenant/operations.ts
@@ -15,6 +15,7 @@
  */
 
 import { Tenant } from 'domain/Tenant';
+import moment from 'moment';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 import { rosterOperations } from 'store/roster';
@@ -105,7 +106,11 @@ ThunkCommandFactory<void, RefreshTenantListAction | any> = () => (dispatch, stat
 
 export const addTenant:
 ThunkCommandFactory<RosterState, AddTenantAction | AddAlertAction> = rs => (dispatch, state, client) => (
-  client.post<Tenant>('/tenant/add', rs).then((tenant) => {
+  client.post<Tenant>('/tenant/add', {
+    ...rs,
+    firstDraftDate: moment(rs.firstDraftDate).local(false).format('YYYY-MM-DD'),
+    lastHistoricDate: moment(rs.lastHistoricDate).local(false).format('YYYY-MM-DD'),
+  }).then((tenant) => {
     dispatch(alert.showSuccessMessage('addTenant', { name: tenant.name }));
     dispatch(actions.addTenant(tenant));
   })

--- a/optaweb-employee-rostering-frontend/src/store/tenant/tenant.test.ts
+++ b/optaweb-employee-rostering-frontend/src/store/tenant/tenant.test.ts
@@ -355,12 +355,12 @@ describe('Tenant operations', () => {
     const { store, client } = mockStore(state);
     const initialRosterState: RosterState = {
       publishNotice: 7,
-      firstDraftDate: new Date('2018-01-01'),
+      firstDraftDate: '2018-01-01' as unknown as Date,
       publishLength: 7,
       draftLength: 7,
       unplannedRotationOffset: 0,
       rotationLength: 7,
-      lastHistoricDate: new Date('2018-01-01'),
+      lastHistoricDate: '2018-01-01' as unknown as Date,
       timeZone: 'America/Toronto',
       tenant: {
         name: 'New Tenant',


### PR DESCRIPTION
Moment tend to convert dates to UTC, which can change the
local date, which is undesired.

Fixes #545 

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
