### PR TITLE
Downgrade JUnit 4 to 4.13

### DIFF
--- a/optaweb-employee-rostering-backend/pom.xml
+++ b/optaweb-employee-rostering-backend/pom.xml
@@ -31,6 +31,12 @@
 
   <properties>
     <java.version>1.8</java.version>
+    <!--
+      Do not upgrade JUnit 4 to a version that is more complex than just MAJOR.MINOR
+      unless the version of JUnit 5 is at least 5.7.0. The junit-vintage-engine < 5.7.0 cannot parse complex versions.
+      See https://github.com/junit-team/junit5/commit/f30c96a9cad89a62a28750c5fe4dd83ad4333e99.
+    -->
+    <version.junit>4.13</version.junit>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- junit-vintage-engine:5.5.2 currently provided by Spring Boot Starter
  Test is not compatible with JUnit 4.13.1.
- We can afford the downgrade because the security problem fixed in
  4.13.1 doesn't affect this project. See
  https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.1.md

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
