### PR TITLE
Fixup junit and validation

### DIFF
--- a/optaweb-employee-rostering-backend/pom.xml
+++ b/optaweb-employee-rostering-backend/pom.xml
@@ -31,12 +31,6 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <!--
-      Do not upgrade JUnit 4 to a version that is more complex than just MAJOR.MINOR
-      unless the version of JUnit 5 is at least 5.7.0. The junit-vintage-engine < 5.7.0 cannot parse complex versions.
-      See https://github.com/junit-team/junit5/commit/f30c96a9cad89a62a28750c5fe4dd83ad4333e99.
-    -->
-    <version.junit>4.13</version.junit>
   </properties>
 
   <dependencies>

--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -26,12 +26,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta.validation</groupId>
-          <artifactId>jakarta.validation-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.optaweb.employeerostering</groupId>
@@ -129,7 +123,7 @@
               <artifactId>process-exec-maven-plugin</artifactId>
               <version>0.9</version>
               <configuration>
-              <skip>${skipITs}</skip>
+                <skip>${skipITs}</skip>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
     <jacoco.agent.argLine/>
     <sonar.projectKey>optaweb-employee-rostering</sonar.projectKey>
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
+    <!--
+      Do not upgrade JUnit 4 to a version that is more complex than just MAJOR.MINOR
+      unless the version of JUnit 5 is at least 5.7.0. The junit-vintage-engine < 5.7.0 cannot parse complex versions.
+      See https://github.com/junit-team/junit5/commit/f30c96a9cad89a62a28750c5fe4dd83ad4333e99.
+    -->
+    <version.junit>4.13</version.junit>
     <version.org.mockito>2.12.0</version.org.mockito>
     <format.directory>${project.basedir}/../ide-configuration</format.directory>
     <formatter.skip>false</formatter.skip>


### PR DESCRIPTION
Fixes up two previous PRs:
- #555: Applies the JUnit downgrade to the benchmark module as well.
- #556: Fixes the standalone module, where validation API became excluded when the Spring Boot upgrade was reverted (https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1579).

### Explanation

#### JUnit downgrade
The incompleteness of #555 is my mistake. I forgot there are two Java modules in this project (backend, benchmark) and no test being executed is difficult to spot (obviously) because there is no failure.

Context: The issue of no tests being executed existed since Oct 26 2020 (https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1500). This is nobody's fault. There was zero chance of discovering this other than by accident because
1. we no longer work on the 7.x branch regularly, and
2. `master` doesn't use JUnit 4. It already uses JUnit 5 so it is completely unaffected by this.

#### Validation API and provider
#556 was incomplete but the problem didn't manifest until the Spring Boot upgrade was reverted. It's a result of temporary inconsistency between kie-parent@master and employee-rostering@7.x.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
