### PR TITLE
Configure docker to run as non-root user

### DIFF
--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -191,6 +191,8 @@
                     <argument>${project.parent.basedir}/${frontend.project.name}:/e2e:Z</argument>
                     <argument>-w</argument>
                     <argument>/e2e</argument>
+                    <argument>${user.flag}</argument>
+                    <argument>${user.name.group}</argument>
                     <argument>--entrypoint</argument>
                     <argument>node</argument>
                     <argument>cypress/included:${version.cypress.docker}</argument>
@@ -206,6 +208,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+    <id>docker</id>
+    <activation>
+      <property>
+        <name>container.runtime</name>
+        <value>docker</value>
+      </property>
+    </activation>
+    <properties>
+      <user.flag>--user</user.flag>
+      <user.name.group>1000:1000</user.name.group>
+    </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
I need to run docker with non-root so to be able to delete files generated inside the container.

Though for podman it is opposite - if you run it as a non-root it is unable to write to the binded volume

I used here 1000:1000 as user and group id since it is a default non-root. So it exist both in container and on host so to not get noisy notifications like:

"groups: cannot find name for group ID"
"I have no name!"
  - your container, complaining
  
That is required for setting up optawebs in the pipeline. So here I made a short version of the pipeline which is also require to be able to remove cypress reports generated in docker

https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/adupliak/job/quickstarts-release-pipeline/job/optaplanner-deploy/83/


Pay attention to the owner it is not root anymore
+ ls -la optaweb-employee-rostering-frontend/target/test-reports/
total 4
drwxr-xr-x. 2 jenkins jenkins   30 Mar  9 12:53 .
drwxrwxr-x. 5 jenkins jenkins  165 Mar  9 12:53 ..
-rw-r--r--. 1 jenkins jenkins 1017 Mar  9 12:53 TEST-cypress.xml



<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
