### PR TITLE
PLANNER-2389 Upgrade Quarkus to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,6 @@
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
     <version.org.mockito>3.7.0</version.org.mockito>
     <version.org.hibernate>5.4.28.Final</version.org.hibernate>
-
-    <!-- TODO: Remove me when optaplanner-build-parent upgrade to 1.11.1.Final or above -->
-    <!-- (Jacoco does not work if below 1.11.1.Final) -->
-    <version.io.quarkus>1.11.1.Final</version.io.quarkus>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,6 @@
     <version.npm>6.14.4</version.npm>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
-    <version.org.mockito>3.7.0</version.org.mockito>
-    <version.org.hibernate>5.4.28.Final</version.org.hibernate>
   </properties>
 
   <modules>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2389

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1254
https://github.com/kiegroup/optaplanner-quickstarts/pull/93
https://github.com/kiegroup/optaweb-employee-rostering/pull/602
https://github.com/kiegroup/optaweb-vehicle-routing/pull/471

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
