### PR TITLE
Make "employeeNotRotationEmployee" not trigger if shift.getRotationEmployee() is null

### DIFF
--- a/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/EmployeeRosteringConstraintProvider.java
+++ b/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/service/solver/EmployeeRosteringConstraintProvider.java
@@ -238,7 +238,7 @@ public final class EmployeeRosteringConstraintProvider implements ConstraintProv
 
     Constraint employeeNotRotationEmployee(ConstraintFactory constraintFactory) {
         return getAssignedShiftConstraintStream(constraintFactory)
-                .filter(shift -> !Objects.equals(shift.getRotationEmployee(), shift.getEmployee()))
+                .filter(shift -> shift.getRotationEmployee() != null && shift.getRotationEmployee() != shift.getEmployee())
                 .penalizeConfigurableLong(CONSTRAINT_EMPLOYEE_IS_NOT_ROTATION_EMPLOYEE, Shift::getLengthInMinutes);
     }
 }

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/AbstractSolverTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/AbstractSolverTest.java
@@ -616,6 +616,10 @@ public abstract class AbstractSolverTest {
 
         shift.setEmployee(rotationEmployee);
         constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
+
+        shift.setEmployee(employeeA);
+        shift.setRotationEmployee(null);
+        constraint.verifyNumOfInstances(scoreVerifier, roster, 0);
     }
 
     protected RosterGenerator buildRosterGenerator() {

--- a/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/DroolsSolverTest.java
+++ b/optaweb-employee-rostering-backend/src/test/java/org/optaweb/employeerostering/solver/DroolsSolverTest.java
@@ -16,9 +16,12 @@
 
 package org.optaweb.employeerostering.solver;
 
+import java.io.File;
+
 import javax.inject.Inject;
 
 import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.optaweb.employeerostering.domain.roster.Roster;
@@ -34,6 +37,10 @@ public class DroolsSolverTest extends AbstractSolverTest {
     @Override
     public SolverFactory<Roster> getSolverFactory() {
         return SolverFactory.create(solverConfig.copyConfig()
+                .withScoreDirectorFactory(new ScoreDirectorFactoryConfig()
+                        .withScoreDrlFiles(new File(DroolsSolverTest.class
+                                .getResource("/org/optaweb/employeerostering/service/solver/employeeRosteringScoreRules.drl")
+                                .getFile())))
                 .withTerminationConfig(
                         new TerminationConfig()
                                 .withBestScoreLimit(AbstractSolverTest.BEST_SCORE_TERMINATION_LIMIT)


### PR DESCRIPTION
There was a difference between scoreDrl and constraint stream
implementations that was not tested in tests. Namely, when
the rotation employee is null and the employee is not null.
The CS impl triggers a penalty, whereas the DRL does not
trigger a penalty. The DRL behavior is the correct one.

As a result of switching to CS by default, this triggers
a NPE on frontend since it creates a employeeNotRotationEmployee
violation with a null rotation employee (which the frontend
assume must not be null).

This adds a test and make CS behave the same as DRL

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
