### PR TITLE
Pass extra arguments from runLocally.sh to java

### DIFF
--- a/runLocally.sh
+++ b/runLocally.sh
@@ -59,11 +59,11 @@ function standalone_jar_or_maven() {
 }
 
 function run_optaweb() {
-  java -jar "$jar"
+  java "$@" -jar "$jar"
 }
 
 # Change dir to the project root (where the script is located).
 cd -P "$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 standalone_jar_or_maven
-run_optaweb
+run_optaweb "$@"


### PR DESCRIPTION
This allows for example to change HTTP port: `./runLocally.sh spain -Dquarkus.http.port=9090`.
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
