### PR TITLE
(8.5.x) RHDM-1737: Use JDK base image so Drools can find a compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /usr/src/optaweb
 COPY . .
 RUN mvn clean install -DskipTests
 
-FROM adoptopenjdk/openjdk11:ubi-minimal-jre
+FROM adoptopenjdk/openjdk11:ubi-minimal
 RUN mkdir /opt/app
 COPY --from=builder /usr/src/optaweb/optaweb-employee-rostering-standalone/target/quarkus-app /opt/app/optaweb-employee-rostering
 CMD ["java", "-jar", "/opt/app/optaweb-employee-rostering/quarkus-run.jar"]

--- a/optaweb-employee-rostering-backend/Dockerfile
+++ b/optaweb-employee-rostering-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:ubi-minimal-jre
+FROM adoptopenjdk/openjdk11:ubi-minimal
 COPY target/quarkus-app /opt/app
 WORKDIR /opt/app
 CMD ["java", "-jar", "quarkus-run.jar"]

--- a/optaweb-employee-rostering-standalone/Dockerfile
+++ b/optaweb-employee-rostering-standalone/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:ubi-minimal-jre
+FROM adoptopenjdk/openjdk11:ubi-minimal
 COPY target/quarkus-app /opt/app
 WORKDIR /opt/app
 CMD ["java", "-jar", "quarkus-run.jar"]


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/RHDM-1737

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
