### PR TITLE
BXMSPROD-1363 [master] build-chain definition and project-dependencies upgraded to v2.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.2
+        uses: kiegroup/github-action-build-chain@v2.6.2
         with:
           # OptaWeb has a different branching model than the rest of KIE. Every OptaWeb 8.x branch maps to master branch
           # in KIE, therefore "master" is hard-coded in the URL below. Once the branching model is unified and there is


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/BXMSPROD-1363

### Referenced pull requests
- https://github.com/kiegroup/optaweb-employee-rostering/pull/639
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/514

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
