### PR TITLE
BXMSPROD-1413 [master] [build-chain upgrade] exclude projects not taken into account

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.2
+        uses: kiegroup/github-action-build-chain@BXMSPROD-1413
         with:
           # OptaWeb has a different branching model than the rest of KIE. Every OptaWeb 8.x branch maps to master branch
           # in KIE, therefore "master" is hard-coded in the URL below. Once the branching model is unified and there is

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@BXMSPROD-1413
+        uses: kiegroup/github-action-build-chain@v2.6.4
         with:
           # OptaWeb has a different branching model than the rest of KIE. Every OptaWeb 8.x branch maps to master branch
           # in KIE, therefore "master" is hard-coded in the URL below. Once the branching model is unified and there is


### PR DESCRIPTION
The build chain tool is not properly taken into account for excluded projects. https://github.com/kiegroup/github-action-build-chain/pull/160 solves the problem

related PR
- https://github.com/kiegroup/github-action-build-chain/pull/160
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/527
- https://github.com/kiegroup/optaweb-employee-rostering/pull/654
- https://github.com/kiegroup/optaplanner/pull/1418
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/528
- https://github.com/kiegroup/optaweb-employee-rostering/pull/655

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
