### PR TITLE
Upload artifacts in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
       # http.keepAlive and maven.wagon.http.pool are used to help stabilize network connection in virtual hosts
       - name: Build with Maven
         run: mvn -B install -Dintegration-tests=true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: artifacts-ci-${{ matrix.os }}-java${{ matrix.java }}
+          path: |
+            **/cypress/screenshots/**
+            **/cypress/videos/**
+            **/target/*.log
+
       # check that git working tree is clean after running npm install via a frontend-maven-plugin
       # the git command returns 1 and fails the build if there are any uncommitted changes
       - name: Check for clean working tree


### PR DESCRIPTION
The CI jobs (from the CI matrix workflow) also fail occasionally. We need the Cypress test video and logs etc. to analyze the issue.
![github-uploaded-artifacts](https://user-images.githubusercontent.com/673386/130368522-73bb359d-8bcc-4a6d-9884-b1682575850c.gif)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
