### PR TITLE
Revert "PLANNER-2504 remove final modifier (workaround)"

### DIFF
--- a/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/shift/Shift.java
+++ b/optaweb-employee-rostering-backend/src/main/java/org/optaweb/employeerostering/domain/shift/Shift.java
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @PlanningEntity(pinningFilter = PinningShiftFilter.class)
 public class Shift extends AbstractPersistable {
     @Transient
-    private AtomicLong lengthInMinutes = new AtomicLong(-1);
+    private final AtomicLong lengthInMinutes = new AtomicLong(-1);
     @ManyToOne
     private Employee rotationEmployee;
     @NotNull

--- a/optaweb-employee-rostering-backend/src/main/resources/application.properties
+++ b/optaweb-employee-rostering-backend/src/main/resources/application.properties
@@ -38,7 +38,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 %test.quarkus.hibernate-orm.database.generation=drop-and-create
 %test.optaweb.generator.initial.data=EMPTY
 %test.optaweb.generator.timeZoneId=UTC
-# Test solution descriptor should use reflection; it appears
-# there is a race condition on Gizmo enhancements causing
-# a test to randomly fail if it is started "too soon"
-%test.quarkus.optaplanner.solver.domain-access-type=REFLECTION


### PR DESCRIPTION
This reverts commit 7f0668848fafe9a20f858c91eb0107b7c839e62c.

Tested locally; can confirm solving works now w/o this workaround.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
