### PR TITLE
[main] BXMSPROD-1475 force maven to 3.8.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         java-version: [11]
+        maven-version: ['3.8.1']
       fail-fast: false
     runs-on: ubuntu-latest
     name: Maven Build
@@ -20,18 +21,19 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           docker rmi $(docker image ls -aq)
           df -h
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Setup Maven And Java Version
+        uses: s4u/setup-maven-action@v1.2.1
         with:
           java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Build Chain ${{ matrix.java-version }}
+          key: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
+      - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.4
         with:


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1475

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1770
* https://github.com/kiegroup/kie-soup/pull/228
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/549
* https://github.com/kiegroup/drools/pull/3835
* https://github.com/kiegroup/optaplanner/pull/1577
* https://github.com/kiegroup/lienzo-core/pull/152
* https://github.com/kiegroup/lienzo-tests/pull/126
* https://github.com/kiegroup/appformer/pull/1197
* https://github.com/kiegroup/kie-uberfire-extensions/pull/124
* https://github.com/kiegroup/jbpm/pull/2024
* https://github.com/kiegroup/kie-jpmml-integration/pull/65
* https://github.com/kiegroup/droolsjbpm-integration/pull/2607
* https://github.com/kiegroup/kie-wb-playground/pull/119
* https://github.com/kiegroup/kie-wb-common/pull/3686
* https://github.com/kiegroup/drools-wb/pull/1515
* https://github.com/kiegroup/jbpm-designer/pull/918
* https://github.com/kiegroup/jbpm-work-items/pull/216
* https://github.com/kiegroup/jbpm-wb/pull/1516
* https://github.com/kiegroup/optaplanner-wb/pull/405
* https://github.com/kiegroup/kie-wb-distributions/pull/1130
* https://github.com/kiegroup/process-migration-service/pull/21
* https://github.com/kiegroup/optaweb-employee-rostering/pull/689
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/560
* https://github.com/kiegroup/kie-docs/pull/3894
* https://github.com/kiegroup/openshift-drools-hacep/pull/118
* https://github.com/kiegroup/optaplanner/pull/1578
* https://github.com/kiegroup/optaweb-employee-rostering/pull/690
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/561