### PR TITLE
Fix some shifts not being editable due to data-popper-reference-hidden=true

### DIFF
--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/EventWrapper.tsx
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/EventWrapper.tsx
@@ -61,7 +61,7 @@ export default function EventWrapper(props: React.PropsWithChildren<{
         appendTo={props.boundary.current}
         zIndex={1000001}
       >
-        <div style={{ maxHeight: '200px' }}>{props.children as React.ReactElement}</div>
+        {props.children as React.ReactElement}
       </Popover>
     </div>
   );

--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/ReactBigCalendarOverrides.css
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/ReactBigCalendarOverrides.css
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-/* The selector .pf-c-popover[data-popper-reference-hidden="true"]
- * seems to be over-eager; hides things that should be visible, so we need to
- * disable it here so popover are shown properly
- */
- .pf-c-popover[data-popper-reference-hidden="true"] {
-     visibility: visible !important;
-     pointer-events: auto;
- }
-
 /* Hack to hide vertical scrollbar on Firefox */
 .rbc-time-content {
     padding-bottom: 6px;

--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/ReactBigCalendarOverrides.css
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/ReactBigCalendarOverrides.css
@@ -15,11 +15,12 @@
  */
 
 /* The selector .pf-c-popover[data-popper-reference-hidden="true"]
- * seems to be over-eagar; hides things that should be visible, so we need to
+ * seems to be over-eager; hides things that should be visible, so we need to
  * disable it here so popover are shown properly
  */
  .pf-c-popover[data-popper-reference-hidden="true"] {
      visibility: visible !important;
+     pointer-events: auto;
  }
 
 /* Hack to hide vertical scrollbar on Firefox */

--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/__snapshots__/EventWrapper.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/__snapshots__/EventWrapper.test.tsx.snap
@@ -17,15 +17,7 @@ exports[`EventWrapper should render correctly when the event continues both befo
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;
 
@@ -46,15 +38,7 @@ exports[`EventWrapper should render correctly when the event continues from earl
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;
 
@@ -75,15 +59,7 @@ exports[`EventWrapper should render correctly when the event continues later 1`]
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;
 
@@ -104,15 +80,7 @@ exports[`EventWrapper should render correctly when the event does not have a cla
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;
 
@@ -133,15 +101,7 @@ exports[`EventWrapper should render correctly when the event does not span multi
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;
 
@@ -160,15 +120,7 @@ exports[`EventWrapper should render correctly when the event has no height or to
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;
 
@@ -186,14 +138,6 @@ exports[`EventWrapper should render correctly without a style 1`] = `
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;

--- a/optaweb-employee-rostering-frontend/src/ui/components/calendar/__snapshots__/Schedule.test.tsx.snap
+++ b/optaweb-employee-rostering-frontend/src/ui/components/calendar/__snapshots__/Schedule.test.tsx.snap
@@ -18,14 +18,6 @@ exports[`Schedule wrapper component should defer to prop 1`] = `
     bodyContent="Body"
     headerContent="Title"
     zIndex={1000001}
-  >
-    <div
-      style={
-        Object {
-          "maxHeight": "200px",
-        }
-      }
-    />
-  </Popover>
+  />
 </div>
 `;


### PR DESCRIPTION
Closes #691
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b>
</details>
