### PR TITLE
Remove needless CORS restrictions

### DIFF
--- a/optaweb-employee-rostering-backend/src/main/resources/application.properties
+++ b/optaweb-employee-rostering-backend/src/main/resources/application.properties
@@ -2,8 +2,6 @@ quarkus.package.type=fast-jar
 
 # CORS
 quarkus.http.cors=true
-quarkus.http.cors.origins=http://localhost:3000
-quarkus.http.cors.methods=GET,PUT,POST
 
 # Swagger UI
 quarkus.swagger-ui.always-include=true


### PR DESCRIPTION
Missing DELETE method makes it impossible to delete shifts in dev mode.

The allowed origin makes it difficult to use the front end dev server on
a different port than 3000.

All this CORS fine-tuning is redundant in dev mode.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b>
</details>
