### PR TITLE
Split nightly jobs

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -1,7 +1,11 @@
+import org.kie.jenkins.jobdsl.model.Folder
 import org.kie.jenkins.jobdsl.templates.KogitoJobTemplate
+import org.kie.jenkins.jobdsl.KogitoJobUtils
 
-def getDefaultJobParams(String repoName = 'optaweb-employee-rostering') {
-    return KogitoJobTemplate.getDefaultJobParams(this, repoName)
+OPTAWEB_EMPLOYEE_ROSTERING = 'optaweb-employee-rostering'
+
+def getDefaultJobParams() {
+    return KogitoJobUtils.getDefaultJobParams(this, OPTAWEB_EMPLOYEE_ROSTERING)
 }
 
 Map getMultijobPRConfig() {
@@ -10,29 +14,15 @@ Map getMultijobPRConfig() {
         buildchain: true,
         jobs : [
             [
-                id: 'optaweb-employee-rostering',
+                id: OPTAWEB_EMPLOYEE_ROSTERING,
                 primary: true,
             ]
         ],
     ]
 }
 
-setupMultijobPrDefaultChecks()
-// setupMultijobPrNativeChecks() // There is no requirement for Native support; there is no Native setup in this repo.
-setupMultijobPrLTSChecks()
+// PR checks
+KogitoJobUtils.createAllEnvsPerRepoPRJobs(this, { jobFolder -> getMultijobPRConfig() }, { return getDefaultJobParams() })
 
-/////////////////////////////////////////////////////////////////
-// Methods
-/////////////////////////////////////////////////////////////////
-
-void setupMultijobPrDefaultChecks() {
-    KogitoJobTemplate.createMultijobPRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
-}
-
-void setupMultijobPrNativeChecks() {
-    KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
-}
-
-void setupMultijobPrLTSChecks() {
-    KogitoJobTemplate.createMultijobLTSPRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
-}
+// Create all Nightly/Release jobs
+KogitoJobUtils.createAllJobsForArtifactsRepository(this, OPTAWEB_EMPLOYEE_ROSTERING, ['optaplanner'])

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,20 +1,8 @@
 #!/bin/bash -e
 
-TEMP_DIR=`mktemp -d`
-
-branch=$1
-author=$2
-
-if [ -z $branch ]; then
-  branch='main'
-fi
-
-if [ -z $author ]; then
-  author='kiegroup'
-fi
-
-echo "----- Cloning pipelines repo from ${author} on branch ${branch}"
-git clone --single-branch --branch ${branch} https://github.com/${author}/kogito-pipelines.git $TEMP_DIR
-
-echo '----- Launching seed tests'
-${TEMP_DIR}/dsl/seed/scripts/seed_test.sh ${TEMP_DIR}
+file=$(mktemp)
+# For more usage of the script, use ./test.sh -h
+# TODO to update before merge
+curl -o ${file} https://raw.githubusercontent.com/radtriste/kogito-pipelines/split_nightly_jobs/dsl/seed/scripts/seed_test.sh
+chmod u+x ${file}
+${file} $@

--- a/.ci/jenkins/scripts/update_version/git_stage_files.groovy
+++ b/.ci/jenkins/scripts/update_version/git_stage_files.groovy
@@ -1,0 +1,9 @@
+void execute(def pipelinesCommon) {
+    githubscm.findAndStageNotIgnoredFiles('pom.xml')
+
+    // Ignore NPM registry
+    sh 'sed \'s;repository.engineering.redhat.com/nexus/repository/;;\' -i */package-lock.json'
+    sh 'git add */package-lock.json'
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/init.groovy
+++ b/.ci/jenkins/scripts/update_version/init.groovy
@@ -1,0 +1,14 @@
+void execute(def pipelinesCommon) {
+    echo 'Hello from init script'
+    if (pipelinesCommon.isRelease() || pipelinesCommon.isCreatePR()) {
+        // Verify version is set
+        assert pipelinesCommon.getOptaPlannerVersion()
+
+        if (pipelinesCommon.isRelease()) {
+            // Verify if on right release branch
+            assert pipelinesCommon.getGitBranch() == util.getReleaseBranchFromVersion(pipelinesCommon.getOptaPlannerVersion())
+        }
+    }
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/main.groovy
+++ b/.ci/jenkins/scripts/update_version/main.groovy
@@ -1,0 +1,5 @@
+void execute(def pipelinesCommon) {
+    maven.mvnVersionsUpdateParentAndChildModules(pipelinesCommon.getDefaultMavenCommand(), pipelinesCommon.getOptaPlannerVersion(), !pipelinesCommon.isRelease())
+}
+
+return this

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Jenkins Tests
+
+on:
+  pull_request:
+    paths:
+      - '.ci/jenkins/**'
+
+jobs:
+  dsl-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout 
+      uses: actions/checkout@v2
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Test DSL
+      run: cd .ci/jenkins/dsl && ./test.sh -b ${{ github.head_ref }} -o ${{ github.event.pull_request.user.login }} -t ${{ github.base_ref }} -a ${{ github.event.pull_request.base.user.login }}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
<!-- 
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b> 
 -->
</details>
