### PR TITLE
Replace node-sass with sass

### DIFF
--- a/optaweb-employee-rostering-frontend/package-lock.json
+++ b/optaweb-employee-rostering-frontend/package-lock.json
@@ -18,7 +18,6 @@
         "i18next-xhr-backend": "^3.2.2",
         "immutable": "^4.0.0-rc.12",
         "moment": "^2.24.0",
-        "node-sass": "^4.14.1",
         "react": "^16.13.1",
         "react-big-calendar": "^0.23.0",
         "react-color": "2.18.1",
@@ -37,6 +36,7 @@
         "redux-devtools-extension": "^2.13.8",
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
+        "sass": "^1.49.0",
         "uuid": "^7.0.2",
         "yaml": "^1.7.2"
       },
@@ -7887,9 +7887,6 @@
     "node_modules/abab": {
       "version": "2.0.4"
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1"
-    },
     "node_modules/accepts": {
       "version": "1.3.7",
       "dependencies": {
@@ -8139,12 +8136,6 @@
     "node_modules/alphanum-sort": {
       "version": "1.0.2"
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "3.2.4",
       "engines": {
@@ -8218,34 +8209,6 @@
         }
       ]
     },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/isarray": {
-      "version": "1.0.0"
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "dependencies": {
@@ -8286,12 +8249,6 @@
     "node_modules/array-filter": {
       "version": "1.0.0",
       "dev": true
-    },
-    "node_modules/array-find-index": {
-      "version": "1.0.2",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/array-flatten": {
       "version": "2.1.2"
@@ -8408,12 +8365,6 @@
     },
     "node_modules/async-each": {
       "version": "1.0.3"
-    },
-    "node_modules/async-foreach": {
-      "version": "0.1.3",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/async-limiter": {
       "version": "1.0.1"
@@ -8907,25 +8858,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "dev": true
-    },
-    "node_modules/block-stream": {
-      "version": "0.0.9",
-      "dependencies": {
-        "inherits": "~2.0.0"
-      },
-      "engines": {
-        "node": "0.4 || >=0.5.8"
-      }
     },
     "node_modules/bluebird": {
       "version": "3.7.2"
@@ -9265,22 +9200,6 @@
       "version": "3.1.0",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "2.1.1",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "2.1.0",
-      "dependencies": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/caniuse-api": {
@@ -9772,12 +9691,6 @@
         "node": ">= 4.0"
       }
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "dependencies": {
@@ -9926,9 +9839,6 @@
     },
     "node_modules/console-browserify": {
       "version": "1.2.0"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0"
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0"
@@ -10464,15 +10374,6 @@
     },
     "node_modules/csstype": {
       "version": "2.6.8"
-    },
-    "node_modules/currently-unhandled": {
-      "version": "0.4.1",
-      "dependencies": {
-        "array-find-index": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/cyclist": {
       "version": "1.0.1"
@@ -11058,9 +10959,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegates": {
-      "version": "1.0.0"
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -12848,10 +12746,6 @@
     "node_modules/file-selector/node_modules/tslib": {
       "version": "2.2.0"
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "optional": true
-    },
     "node_modules/filesize": {
       "version": "6.0.1",
       "engines": {
@@ -13123,37 +13017,6 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0"
     },
-    "node_modules/fsevents": {
-      "version": "2.1.2",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1"
     },
@@ -13176,28 +13039,6 @@
       "version": "1.2.1",
       "dev": true
     },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gaze": {
-      "version": "1.1.3",
-      "dependencies": {
-        "globule": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.1",
       "engines": {
@@ -13215,12 +13056,6 @@
     },
     "node_modules/get-own-enumerable-property-symbols": {
       "version": "3.0.2"
-    },
-    "node_modules/get-stdin": {
-      "version": "4.0.1",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/get-stream": {
       "version": "4.1.0",
@@ -13362,17 +13197,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/globule": {
-      "version": "1.3.2",
-      "dependencies": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.10",
-        "minimatch": "~3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.3"
     },
@@ -13449,9 +13273,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1"
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -13845,7 +13666,9 @@
       "version": "1.10.0"
     },
     "node_modules/immutable": {
-      "version": "4.0.0-rc.12"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
     "node_modules/import-cwd": {
       "version": "2.1.0",
@@ -13898,15 +13721,6 @@
       "version": "0.1.4",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/in-publish": {
-      "version": "2.0.1",
-      "bin": {
-        "in-install": "in-install.js",
-        "in-publish": "in-publish.js",
-        "not-in-install": "not-in-install.js",
-        "not-in-publish": "not-in-publish.js"
       }
     },
     "node_modules/indexes-of": {
@@ -14214,21 +14028,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-finite": {
-      "version": "1.1.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
       "engines": {
@@ -14402,9 +14201,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-utf8": {
-      "version": "0.2.1"
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -14733,21 +14529,6 @@
       },
       "optionalDependencies": {
         "fsevents": "^1.2.7"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/fsevents": {
-      "version": "1.2.13",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/jest-jasmine2": {
@@ -15134,9 +14915,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/js-base64": {
-      "version": "2.6.3"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0"
     },
@@ -15396,28 +15174,6 @@
     "node_modules/listr2/node_modules/tslib": {
       "version": "2.3.1",
       "dev": true
-    },
-    "node_modules/load-json-file": {
-      "version": "1.1.0",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/load-json-file/node_modules/parse-json": {
-      "version": "2.2.0",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/loader-fs-cache": {
       "version": "1.0.3",
@@ -15749,23 +15505,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loud-rejection": {
-      "version": "1.6.0",
-      "dependencies": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "4.1.5",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "dependencies": {
@@ -15793,12 +15532,6 @@
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/map-obj": {
-      "version": "1.0.1",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15867,24 +15600,6 @@
       "version": "1.1.1",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/meow": {
-      "version": "3.7.0",
-      "dependencies": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/merge-deep": {
@@ -16239,9 +15954,6 @@
     "node_modules/mute-stream": {
       "version": "0.0.8"
     },
-    "node_modules/nan": {
-      "version": "2.14.0"
-    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "dependencies": {
@@ -16306,53 +16018,6 @@
       "version": "0.10.0",
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/node-gyp": {
-      "version": "3.8.0",
-      "dependencies": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/nopt": {
-      "version": "3.0.6",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
-    "node_modules/node-gyp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "5.3.0",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/node-int64": {
@@ -16447,67 +16112,6 @@
     "node_modules/node-releases": {
       "version": "1.1.61"
     },
-    "node_modules/node-sass": {
-      "version": "4.14.1",
-      "hasInstallScript": true,
-      "dependencies": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
-        "request": "^2.88.0",
-        "sass-graph": "2.2.5",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
-      },
-      "bin": {
-        "node-sass": "bin/node-sass"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/chalk": {
-      "version": "1.1.3",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-sass/node_modules/cross-spawn": {
-      "version": "3.0.1",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/node-sass/node_modules/supports-color": {
-      "version": "2.0.0",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "dependencies": {
@@ -16553,15 +16157,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "node_modules/nth-check": {
       "version": "1.0.2",
       "dependencies": {
@@ -16570,12 +16165,6 @@
     },
     "node_modules/num2fraction": {
       "version": "1.2.2"
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.0"
@@ -16813,23 +16402,10 @@
     "node_modules/os-browserify": {
       "version": "0.3.0"
     },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/osenv": {
-      "version": "0.1.5",
-      "dependencies": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
       }
     },
     "node_modules/ospath": {
@@ -18237,9 +17813,6 @@
     "node_modules/prr": {
       "version": "1.0.1"
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2"
-    },
     "node_modules/psl": {
       "version": "1.7.0"
     },
@@ -19143,38 +18716,6 @@
         "lodash": "^4.0.1"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "1.1.0",
-      "dependencies": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "1.0.1",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/path-type": {
-      "version": "1.1.0",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "1.0.34",
       "dependencies": {
@@ -19216,25 +18757,6 @@
       "version": "2.2.2",
       "dependencies": {
         "minimatch": "3.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/redent": {
-      "version": "1.0.0",
-      "dependencies": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/redent/node_modules/indent-string": {
-      "version": "2.1.0",
-      "dependencies": {
-        "repeating": "^2.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -19403,15 +18925,6 @@
       "version": "1.6.1",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/repeating": {
-      "version": "2.0.1",
-      "dependencies": {
-        "is-finite": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/request": {
@@ -19735,13 +19248,20 @@
     "node_modules/sanitize.css": {
       "version": "10.0.0"
     },
-    "node_modules/sass-graph": {
-      "version": "2.2.5",
+    "node_modules/sass": {
+      "version": "1.49.9",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
+      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
       "dependencies": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^13.3.2"
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/sass-loader": {
@@ -19830,22 +19350,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "node_modules/scss-tokenizer": {
-      "version": "0.2.3",
-      "dependencies": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
-      }
-    },
-    "node_modules/scss-tokenizer/node_modules/source-map": {
-      "version": "0.4.4",
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/select-hose": {
@@ -20336,6 +19840,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-resolve": {
       "version": "0.5.3",
       "dependencies": {
@@ -20514,33 +20026,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/stdout-stream": {
-      "version": "1.4.1",
-      "dependencies": {
-        "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/stdout-stream/node_modules/isarray": {
-      "version": "1.0.0"
-    },
-    "node_modules/stdout-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/stdout-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "engines": {
@@ -20654,17 +20139,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "1.0.2",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -20830,15 +20304,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "2.0.0",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-comments": {
       "version": "1.0.2",
       "dependencies": {
@@ -20860,18 +20325,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "1.0.1",
-      "dependencies": {
-        "get-stdin": "^4.0.1"
-      },
-      "bin": {
-        "strip-indent": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -21022,14 +20475,6 @@
       "version": "1.1.3",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "2.2.2",
-      "dependencies": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
       }
     },
     "node_modules/terser": {
@@ -21366,18 +20811,6 @@
       "version": "1.0.1",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/trim-newlines": {
-      "version": "1.0.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/true-case-path": {
-      "version": "1.0.3",
-      "dependencies": {
-        "glob": "^7.1.2"
       }
     },
     "node_modules/ts-pnp": {
@@ -21751,127 +21184,6 @@
         "watchpack-chokidar2": "^2.0.0"
       }
     },
-    "node_modules/watchpack-chokidar2": {
-      "version": "2.0.0",
-      "optional": true,
-      "dependencies": {
-        "chokidar": "^2.1.8"
-      },
-      "engines": {
-        "node": "<8.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/binary-extensions": {
-      "version": "1.13.1",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/chokidar": {
-      "version": "2.1.8",
-      "optional": true,
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/fsevents": {
-      "version": "1.2.13",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "optional": true,
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "optional": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/is-binary-path": {
-      "version": "1.0.1",
-      "optional": true,
-      "dependencies": {
-        "binary-extensions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/isarray": {
-      "version": "1.0.0",
-      "optional": true
-    },
-    "node_modules/watchpack-chokidar2/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "optional": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/readdirp": {
-      "version": "2.2.1",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/wbuf": {
       "version": "1.7.3",
       "dependencies": {
@@ -22001,21 +21313,6 @@
       "version": "4.1.1",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/fsevents": {
-      "version": "1.2.13",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/glob-parent": {
@@ -22306,12 +21603,6 @@
     "node_modules/which-module": {
       "version": "2.0.0"
     },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "node_modules/windows-iana": {
       "version": "3.1.0",
       "dev": true
@@ -22587,9 +21878,6 @@
     },
     "node_modules/y18n": {
       "version": "4.0.0"
-    },
-    "node_modules/yallist": {
-      "version": "2.1.2"
     },
     "node_modules/yaml": {
       "version": "1.7.2",
@@ -30544,9 +29832,6 @@
     "abab": {
       "version": "2.0.4"
     },
-    "abbrev": {
-      "version": "1.1.1"
-    },
     "accepts": {
       "version": "1.3.7",
       "requires": {
@@ -30746,9 +30031,6 @@
     "alphanum-sort": {
       "version": "1.0.2"
     },
-    "amdefine": {
-      "version": "1.0.1"
-    },
     "ansi-colors": {
       "version": "3.2.4"
     },
@@ -30789,36 +30071,6 @@
       "version": "2.2.0",
       "dev": true
     },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "requires": {
@@ -30850,9 +30102,6 @@
     "array-filter": {
       "version": "1.0.0",
       "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2"
     },
     "array-flatten": {
       "version": "2.1.2"
@@ -30944,9 +30193,6 @@
     },
     "async-each": {
       "version": "1.0.3"
-    },
-    "async-foreach": {
-      "version": "0.1.3"
     },
     "async-limiter": {
       "version": "1.0.1"
@@ -31370,22 +30616,9 @@
     "binary-extensions": {
       "version": "2.1.0"
     },
-    "bindings": {
-      "version": "1.5.0",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "blob-util": {
       "version": "2.0.2",
       "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "requires": {
-        "inherits": "~2.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2"
@@ -31688,16 +30921,6 @@
     },
     "callsites": {
       "version": "3.1.0"
-    },
-    "camelcase": {
-      "version": "2.1.1"
-    },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      }
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -32060,9 +31283,6 @@
         "q": "^1.1.2"
       }
     },
-    "code-point-at": {
-      "version": "1.1.0"
-    },
     "collection-visit": {
       "version": "1.0.0",
       "requires": {
@@ -32189,9 +31409,6 @@
     },
     "console-browserify": {
       "version": "1.2.0"
-    },
-    "console-control-strings": {
-      "version": "1.1.0"
     },
     "constants-browserify": {
       "version": "1.0.0"
@@ -32596,12 +31813,6 @@
     },
     "csstype": {
       "version": "2.6.8"
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
     },
     "cyclist": {
       "version": "1.0.1"
@@ -33024,9 +32235,6 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0"
-    },
-    "delegates": {
       "version": "1.0.0"
     },
     "depd": {
@@ -34469,10 +33677,6 @@
         }
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "optional": true
-    },
     "filesize": {
       "version": "6.0.1"
     },
@@ -34696,27 +33900,6 @@
     "fs.realpath": {
       "version": "1.0.0"
     },
-    "fsevents": {
-      "version": "2.1.2",
-      "optional": true
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1"
     },
@@ -34736,25 +33919,6 @@
       "version": "1.2.1",
       "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "gaze": {
-      "version": "1.1.3",
-      "requires": {
-        "globule": "^1.0.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.1"
     },
@@ -34769,9 +33933,6 @@
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2"
-    },
-    "get-stdin": {
-      "version": "4.0.1"
     },
     "get-stream": {
       "version": "4.1.0",
@@ -34879,14 +34040,6 @@
         }
       }
     },
-    "globule": {
-      "version": "1.3.2",
-      "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.10",
-        "minimatch": "~3.0.2"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.3"
     },
@@ -34941,9 +34094,6 @@
     },
     "has-symbols": {
       "version": "1.0.1"
-    },
-    "has-unicode": {
-      "version": "2.0.1"
     },
     "has-value": {
       "version": "1.0.0",
@@ -35292,7 +34442,9 @@
       "version": "1.10.0"
     },
     "immutable": {
-      "version": "4.0.0-rc.12"
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -35327,9 +34479,6 @@
     },
     "imurmurhash": {
       "version": "0.1.4"
-    },
-    "in-publish": {
-      "version": "2.0.1"
     },
     "indexes-of": {
       "version": "1.0.1"
@@ -35544,15 +34693,6 @@
     "is-extglob": {
       "version": "2.1.1"
     },
-    "is-finite": {
-      "version": "1.1.0"
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
     "is-generator-fn": {
       "version": "2.1.0"
     },
@@ -35659,9 +34799,6 @@
     "is-unicode-supported": {
       "version": "0.1.0",
       "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1"
     },
     "is-windows": {
       "version": "1.0.2"
@@ -35941,16 +35078,6 @@
         "micromatch": "^3.1.10",
         "sane": "^4.0.3",
         "walker": "^1.0.7"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "1.2.13",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
-        }
       }
     },
     "jest-jasmine2": {
@@ -36237,9 +35364,6 @@
         }
       }
     },
-    "js-base64": {
-      "version": "2.6.3"
-    },
     "js-tokens": {
       "version": "4.0.0"
     },
@@ -36436,24 +35560,6 @@
         "tslib": {
           "version": "2.3.1",
           "dev": true
-        }
-      }
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "2.2.0",
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
         }
       }
     },
@@ -36704,20 +35810,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "requires": {
@@ -36741,9 +35833,6 @@
     },
     "map-cache": {
       "version": "0.2.2"
-    },
-    "map-obj": {
-      "version": "1.0.1"
     },
     "map-visit": {
       "version": "1.0.0",
@@ -36805,21 +35894,6 @@
             "safe-buffer": "~5.1.0"
           }
         }
-      }
-    },
-    "meow": {
-      "version": "3.7.0",
-      "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
       }
     },
     "merge-deep": {
@@ -37105,9 +36179,6 @@
     "mute-stream": {
       "version": "0.0.8"
     },
-    "nan": {
-      "version": "2.14.0"
-    },
     "nanomatch": {
       "version": "1.2.13",
       "requires": {
@@ -37157,40 +36228,6 @@
     },
     "node-forge": {
       "version": "0.10.0"
-    },
-    "node-gyp": {
-      "version": "3.8.0",
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "3.0.6",
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.3.0"
-        }
-      }
     },
     "node-int64": {
       "version": "0.4.0"
@@ -37289,53 +36326,6 @@
     "node-releases": {
       "version": "1.1.61"
     },
-    "node-sass": {
-      "version": "4.14.1",
-      "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
-        "request": "^2.88.0",
-        "sass-graph": "2.2.5",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "3.0.1",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        }
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "requires": {
@@ -37369,15 +36359,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "nth-check": {
       "version": "1.0.2",
       "requires": {
@@ -37386,9 +36367,6 @@
     },
     "num2fraction": {
       "version": "1.2.2"
-    },
-    "number-is-nan": {
-      "version": "1.0.1"
     },
     "nwsapi": {
       "version": "2.2.0"
@@ -37563,18 +36541,8 @@
     "os-browserify": {
       "version": "0.3.0"
     },
-    "os-homedir": {
-      "version": "1.0.2"
-    },
     "os-tmpdir": {
       "version": "1.0.2"
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "ospath": {
       "version": "1.2.2",
@@ -38692,9 +37660,6 @@
     "prr": {
       "version": "1.0.1"
     },
-    "pseudomap": {
-      "version": "1.0.2"
-    },
     "psl": {
       "version": "1.7.0"
     },
@@ -39447,31 +38412,6 @@
         "lodash": "^4.0.1"
       }
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "1.1.0",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      }
-    },
     "readable-stream": {
       "version": "1.0.34",
       "requires": {
@@ -39504,21 +38444,6 @@
       "version": "2.2.2",
       "requires": {
         "minimatch": "3.0.4"
-      }
-    },
-    "redent": {
-      "version": "1.0.0",
-      "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "2.1.0",
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        }
       }
     },
     "redux": {
@@ -39656,12 +38581,6 @@
     },
     "repeat-string": {
       "version": "1.6.1"
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
     },
     "request": {
       "version": "2.88.0",
@@ -39917,13 +38836,14 @@
     "sanitize.css": {
       "version": "10.0.0"
     },
-    "sass-graph": {
-      "version": "2.2.5",
+    "sass": {
+      "version": "1.49.9",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
+      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^13.3.2"
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
     "sass-loader": {
@@ -39993,21 +38913,6 @@
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
-          }
-        }
-      }
-    },
-    "scss-tokenizer": {
-      "version": "0.2.3",
-      "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "requires": {
-            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -40401,6 +39306,11 @@
     "source-map": {
       "version": "0.6.1"
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "requires": {
@@ -40560,35 +39470,6 @@
     "statuses": {
       "version": "1.5.0"
     },
-    "stdout-stream": {
-      "version": "1.4.1",
-      "requires": {
-        "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "stealthy-require": {
       "version": "1.1.1"
     },
@@ -40690,14 +39571,6 @@
             "ansi-regex": "^3.0.0"
           }
         }
-      }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.matchall": {
@@ -40827,12 +39700,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
     "strip-comments": {
       "version": "1.0.2",
       "requires": {
@@ -40846,12 +39713,6 @@
     "strip-final-newline": {
       "version": "2.0.0",
       "dev": true
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "requires": {
-        "get-stdin": "^4.0.1"
-      }
     },
     "strip-json-comments": {
       "version": "3.1.1"
@@ -40963,14 +39824,6 @@
     },
     "tapable": {
       "version": "1.1.3"
-    },
-    "tar": {
-      "version": "2.2.2",
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
     },
     "terser": {
       "version": "4.8.0",
@@ -41211,15 +40064,6 @@
       "version": "1.0.1",
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "trim-newlines": {
-      "version": "1.0.0"
-    },
-    "true-case-path": {
-      "version": "1.0.3",
-      "requires": {
-        "glob": "^7.1.2"
       }
     },
     "ts-pnp": {
@@ -41513,106 +40357,6 @@
         "watchpack-chokidar2": "^2.0.0"
       }
     },
-    "watchpack-chokidar2": {
-      "version": "2.0.0",
-      "optional": true,
-      "requires": {
-        "chokidar": "^2.1.8"
-      },
-      "dependencies": {
-        "binary-extensions": {
-          "version": "1.13.1",
-          "optional": true
-        },
-        "chokidar": {
-          "version": "2.1.8",
-          "optional": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        },
-        "fsevents": {
-          "version": "1.2.13",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "optional": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "optional": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "optional": true,
-          "requires": {
-            "binary-extensions": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "optional": true
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "optional": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "readdirp": {
-          "version": "2.2.1",
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "wbuf": {
       "version": "1.7.3",
       "requires": {
@@ -41799,14 +40543,6 @@
             "ms": "^2.1.1"
           }
         },
-        "fsevents": {
-          "version": "1.2.13",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
-        },
         "glob-parent": {
           "version": "3.1.0",
           "requires": {
@@ -41966,12 +40702,6 @@
     },
     "which-module": {
       "version": "2.0.0"
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
     },
     "windows-iana": {
       "version": "3.1.0",
@@ -42213,9 +40943,6 @@
     },
     "y18n": {
       "version": "4.0.0"
-    },
-    "yallist": {
-      "version": "2.1.2"
     },
     "yaml": {
       "version": "1.7.2",

--- a/optaweb-employee-rostering-frontend/package.json
+++ b/optaweb-employee-rostering-frontend/package.json
@@ -14,7 +14,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "immutable": "^4.0.0-rc.12",
     "moment": "^2.24.0",
-    "node-sass": "^4.14.1",
+    "sass": "^1.49.0",
     "react": "^16.13.1",
     "react-big-calendar": "^0.23.0",
     "react-color": "2.18.1",


### PR DESCRIPTION
Fixes #753. `node-sass` is now deprecated, and it recommended to use `sass` instead: https://www.npmjs.com/package/node-sass
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
<!-- 
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b> 
 -->
</details>
