### PR TITLE
[7.x] RHPAM-4111: Update dependencies to match Spring Boot 2.4.9

### DIFF
--- a/optaweb-employee-rostering-backend/pom.xml
+++ b/optaweb-employee-rostering-backend/pom.xml
@@ -149,6 +149,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>

--- a/optaweb-employee-rostering-benchmark/pom.xml
+++ b/optaweb-employee-rostering-benchmark/pom.xml
@@ -64,6 +64,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,8 @@
     <jacoco.agent.argLine/>
     <sonar.projectKey>optaweb-employee-rostering</sonar.projectKey>
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
-    <!--
-      Do not upgrade JUnit 4 to a version that is more complex than just MAJOR.MINOR
-      unless the version of JUnit 5 is at least 5.7.0. The junit-vintage-engine < 5.7.0 cannot parse complex versions.
-      See https://github.com/junit-team/junit5/commit/f30c96a9cad89a62a28750c5fe4dd83ad4333e99.
-    -->
-    <version.junit>4.13</version.junit>
-    <version.org.mockito>2.12.0</version.org.mockito>
+    <version.org.junit>5.7.2</version.org.junit>
+    <version.org.mockito>3.6.28</version.org.mockito>
     <format.directory>${project.basedir}/../ide-configuration</format.directory>
     <formatter.skip>false</formatter.skip>
     <formatter.goal>format</formatter.goal>


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/RHPAM-4111

### Referenced pull requests
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1872
- https://github.com/kiegroup/droolsjbpm-integration/pull/2693
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/641
- https://github.com/kiegroup/optaweb-employee-rostering/pull/755

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
<!-- 
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b> 
 -->
</details>
