### PR TITLE
[1.13.x] Prepare branch for productization

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -18,7 +18,7 @@ Map getMultijobPRConfig() {
 }
 
 setupMultijobPrDefaultChecks()
-setupMultijobPrNativeChecks()
+// setupMultijobPrNativeChecks() // There is no requirement for Native support; there is no Native setup in this repo.
 setupMultijobPrLTSChecks()
 
 /////////////////////////////////////////////////////////////////

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -31,23 +31,23 @@ jobs:
     name: Full downstream build
     steps:
       - name: Clean Disk Space
-        uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@1.13.x
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Support long paths
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@1.13.x
       - name: Java and Maven Setup
-        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/maven@1.13.x
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
       - name: Build Chain
-        uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@1.13.x
         with:
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           flow-type: full-downstream
       - name: Surefire Report
-        uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@1.13.x
         if: ${{ always() }}

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -2,6 +2,7 @@ name: Build Chain
 
 on:
   pull_request:
+    types: [labeled]
     branches:
       - main
       - 8.*
@@ -13,19 +14,21 @@ on:
       - '*.txt'
       - 'runOnOpenShift.sh'
       - 'ide-configuration/**'
+
 jobs:
   build-chain:
+    if: contains(github.event.pull_request.labels.*.name, 'run_fdb')
     concurrency:
-      group: pull_request-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.java-version }}
+      group: fdb-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: [11, 17]
+        java-version: [11]
         maven-version: ['3.8.1']
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
+    name: Full downstream build
     steps:
       - name: Clean Disk Space
         uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@main
@@ -42,9 +45,9 @@ jobs:
       - name: Build Chain
         uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/%{process.env.GITHUB_BASE_REF.replace(/(\d*)\.(.*)\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          flow-type: full-downstream
       - name: Surefire Report
         uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@main
         if: ${{ always() }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,23 +28,23 @@ jobs:
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
     steps:
       - name: Clean Disk Space
-        uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/ubuntu-disk-space@1.13.x
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Support long paths
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@1.13.x
       - name: Java and Maven Setup
-        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/maven@1.13.x
         with:
           java-version: ${{ matrix.java-version }}
           maven-version: ${{ matrix.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
       - name: Build Chain
-        uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@1.13.x
         with:
           definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/%{process.env.GITHUB_BASE_REF.replace(/(\d*)\.(.*)\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)}/.ci/pull-request-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report
-        uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@main
+        uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@1.13.x
         if: ${{ always() }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,53 @@
+# Runs SonarCloud analysis of the main branch after a PR is merged.
+name: SonarCloud analysis
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'LICENSE*'
+      - 'CODEOWNERS'
+      - '.gitignore'
+      - '.gitattributes'
+      - '**.md'
+      - '**.adoc'
+      - '**.txt'
+      - 'runOnOpenShift.sh'
+      - 'runLocally.sh'
+      - '.ci/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sonarcloud-analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build with Maven to measure code coverage
+        run: mvn -B --fail-at-end clean install -Prun-code-coverage
+      - name: Run SonarCloud analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: mvn -B --fail-at-end validate -Psonarcloud-analysis -Dsonar.login=${{ env.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
Depends on https://github.com/kiegroup/kogito-pipelines/pull/388

I backported changes from `main` which are useful and removed drools references.

- https://github.com/kiegroup/kogito-pipelines/pull/388
- https://github.com/kiegroup/kogito-pipelines/pull/390
- https://github.com/kiegroup/kogito-runtimes/pull/2028
- https://github.com/kiegroup/optaplanner/pull/1850
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/662
- https://github.com/kiegroup/optaweb-employee-rostering/pull/771
- https://github.com/kiegroup/optaplanner-quickstarts/pull/295
- https://github.com/kiegroup/kogito-apps/pull/1258
- https://github.com/kiegroup/kogito-examples/pull/1144
- https://github.com/kiegroup/kogito-images/pull/1126
- https://github.com/kiegroup/kogito-operator/pull/1139