### PR TITLE
Run docker and podman with current user UID

### DIFF
--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -175,24 +175,12 @@
                 </goals>
                 <configuration>
                   <skip>${skipITs}</skip>
-                  <executable>${container.runtime}</executable>
+                  <executable>${project.basedir}/run_tests.sh</executable>
                   <arguments>
-                    <argument>run</argument>
-                    <argument>--network=host</argument> <!-- Cypress accesses UI running on the host -->
-                    <argument>-v</argument>
-                    <argument>${project.parent.basedir}/${frontend.project.name}:/e2e:Z</argument>
-                    <argument>-w</argument>
-                    <argument>/e2e</argument>
-                    <argument>${user.flag}</argument>
-                    <argument>${user.name.group}</argument>
-                    <argument>--entrypoint</argument>
-                    <argument>cypress</argument>
-                    <argument>docker.io/cypress/included:${version.cypress.docker}</argument>
-                    <argument>run</argument> <!-- Executing cypress:run -->
-                    <argument>--project</argument>
-                    <argument>.</argument>
-                    <argument>--config</argument>
-                    <argument>baseUrl=http://localhost:${application.port}</argument>
+                    <argument>${container.runtime}</argument>
+                    <argument>${maven.multiModuleProjectDirectory}${file.separator}${frontend.project.name}</argument>
+                    <argument>${version.cypress.docker}</argument>
+                    <argument>${application.port}</argument>
                   </arguments>
                 </configuration>
               </execution>
@@ -200,19 +188,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-    <id>docker</id>
-    <activation>
-      <property>
-        <name>container.runtime</name>
-        <value>docker</value>
-      </property>
-    </activation>
-    <properties>
-      <user.flag>--user</user.flag>
-      <user.name.group>1000:1000</user.name.group>
-    </properties>
     </profile>
   </profiles>
 </project>

--- a/optaweb-employee-rostering-standalone/run_tests.sh
+++ b/optaweb-employee-rostering-standalone/run_tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+readonly CONTAINER_RUNTIME=$1
+readonly FRONTEND_PROJECT_PATH=$2
+readonly VERSION_CYPRESS=$3
+readonly APPLICATION_PORT=$4
+
+user_command="--user  $(id -u):$(id -g)"
+
+if [[ "$CONTAINER_RUNTIME" == "podman" ]]
+then
+    user_command="${user_command} --userns=keep-id"
+fi
+
+echo "$CONTAINER_RUNTIME run --network=host \
+                          -v $FRONTEND_PROJECT_PATH:/e2e:Z \
+                          $user_command \
+                          -w /e2e --entrypoint cypress docker.io/cypress/included:$VERSION_CYPRESS \
+                          run --project . --config baseUrl=http://localhost:$APPLICATION_PORT" > cypress-test-run.sh
+sh cypress-test-run.sh
+


### PR DESCRIPTION
After cypress tests gets executed it writes video under cypress/videos.
Jenkins uses rootfull docker by default so the videos ownership is root

The Jenkins agent fails to clean up the files since it use jenkins user instead of root.

Podman require write access to the mounted folder as well so even thought it is rootless by default it needs to have UID to write.
userns=keep-id maps host user to be the same as container user

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2695

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
<!-- 
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b> 
 -->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
