### PR TITLE
Update code formater + badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,12 +4,13 @@
 
 = Employee Rostering Optimization as a Service
 
-image:https://travis-ci.com/kiegroup/optaweb-employee-rostering.svg?branch=main[
-"Build Status", link="https://travis-ci.com/kiegroup/optaweb-employee-rostering"]
-image:https://img.shields.io/badge/stackoverflow-ask_question-orange.svg?logo=stackoverflow[
-"Ask question on Stack Overflow", link="https://stackoverflow.com/questions/tagged/optaweb-employee-rostering"]
-image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?logo=zulip[
+image:https://img.shields.io/badge/stackoverflow-ask_question-orange.svg?logo=stackoverflow&style=for-the-badge["Ask question on Stack Overflow", link="https://stackoverflow.com/questions/tagged/optaweb-employee-rostering"]
+image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?logo=zulip&style=for-the-badge[
 "Join Zulip Chat", link="https://kie.zulipchat.com/#narrow/stream/232679-optaplanner"]
+image:https://img.shields.io/github/commit-activity/m/kiegroup/optaweb-employee-rostering?label=commits&style=for-the-badge["Commit Activity", link="https://github.com/kiegroup/optaweb-employee-rostering/pulse"]
+image:https://img.shields.io/github/license/kiegroup/optaweb-employee-rostering?style=for-the-badge&logo=apache["License", link="https://www.apache.org/licenses/LICENSE-2.0"]
+image:https://img.shields.io/badge/JVM-11-green?style=for-the-badge["JVM support", link="https://github.com/dupliaka/optaweb-employee-rostering/actions"]
+image:https://img.shields.io/badge/Maven-3.x-blue?style=for-the-badge["Maven",link="https://maven.apache.org/install.html"]
 
 {sonarBadge}&metric=alert_status["Quality Gate Status", {sonarLink}]
 {sonarBadge}&metric=reliability_rating["Reliability Rating", {sonarLink}]
@@ -142,7 +143,7 @@ oc start-build frontend --from-dir=docker --follow
 
 === Code formatter
 
-Both IntelliJ and Eclipse formatters are available here: https://github.com/kiegroup/droolsjbpm-build-bootstrap/tree/main/ide-configuration
+IntelliJ, Eclipse and VS Code formatters https://github.com/kiegroup/optaplanner/blob/main/build/optaplanner-ide-config/ide-configuration.adoc#ide-setup-instructions[IDE setup instructions].
 
 === Backend
 


### PR DESCRIPTION
Linking OptaPlanner instructions
Removed sonar gate badge + added similar from OptaPlanner parent badges

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->
https://issues.redhat.com/browse/PLANNER-2684
### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] LTS</b>
<!-- 
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b> 
 -->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
