### PR TITLE
Add width to the calendar element + make tenant name unique

### DIFF
--- a/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
+++ b/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
@@ -66,10 +66,11 @@ describe('A new tenant can be created, who can have their own employees, spots, 
   });
 
   it('basic tenant workflow', () => {
+    const uniqueTenantName = 'Test Tenant ' + new Date().getTime() ;
     // Create a tenant
     cy.get('[data-cy=settings]').click();
     cy.get('[data-cy=data-table-add]').click();
-    cy.get('[data-cy=name]').type('Test Tenant');
+    cy.get('[data-cy=name]').type(uniqueTenantName);
     cy.get('[data-cy=schedule-start-date]').type('2018-01-01');
     cy.get('[data-cy=draft-length]').type('7');
     cy.get('[data-cy=publish-notice]').type('7');
@@ -81,7 +82,7 @@ describe('A new tenant can be created, who can have their own employees, spots, 
     cy.get('[data-cy=save]').click();
     closeAlerts();
 
-    changeToTenant('Test Tenant');
+    changeToTenant(uniqueTenantName);
 
     // Create a new skill
     gotoPage('skills');

--- a/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
+++ b/optaweb-employee-rostering-frontend/cypress/integration/newTenantBasicWorkflow.js
@@ -66,7 +66,7 @@ describe('A new tenant can be created, who can have their own employees, spots, 
   });
 
   it('basic tenant workflow', () => {
-    const uniqueTenantName = 'Test Tenant ' + new Date().getTime() ;
+    const uniqueTenantName = `Test Tenant ${new Date().getTime()}`;
     // Create a tenant
     cy.get('[data-cy=settings]').click();
     cy.get('[data-cy=data-table-add]').click();

--- a/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.css
+++ b/optaweb-employee-rostering-frontend/src/ui/components/WeekPicker.css
@@ -15,6 +15,7 @@
  */
  .week-picker-container {
     background-color: var(--pf-global--BackgroundColor--100);
+    width: max-content;
  }
 
 .week-picker {


### PR DESCRIPTION
To avoid element squeezing to the calendar due to small display settings I have added width attribute

+ To be able repeatedly test the app - made tenant name unique

https://qe-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/TESTING/job/7.13/job/KOGITO_RUNTIMES-CR/job/community/job/baseline/job/optaweb-employee-rostering-openshift-baseline/3/artifact/run-tests-with-build-project-sources-dependency-get/target/sources/optaweb-employee-rostering-8.13.0.Final-redhat-00003/optaweb-employee-rostering-frontend/cypress/screenshots/newTenantBasicWorkflow.js/basic-tenant-workflow%20(failed).png

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job:  
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job:  
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] quarkus-branch</b>

<!-- - for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] mandrel</b> -->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
