### PR TITLE
[PLANNER-2728] Extract optaplanner release from Kogito

### DIFF
--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
+
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO=kiegroup/optaplanner
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REF=main
+export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
+
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
 curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -10,13 +10,9 @@ jobs:
   dsl-tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout 
-      uses: actions/checkout@v2
-
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v1
+    - name: DSL tests
+      uses: kiegroup/kogito-pipelines/.ci/actions/dsl-tests@main
       with:
-        java-version: 11
-
-    - name: Test DSL
-      run: .ci/jenkins/dsl/test.sh -h ${{ github.head_ref }} -r ${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.base_ref }} -t ${{ github.event.pull_request.base.repo.full_name }} .ci/jenkins/dsl
+        main-config-file-repo: kiegroup/optaplanner
+        main-config-file-ref: main
+        main-config-file-path: .ci/jenkins/config/main.yaml


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job:  
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job:  
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] quarkus-branch</b>

<!-- - for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaweb-employee-rostering] mandrel</b> -->
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
