### PR TITLE
Run docker and podman with current user UID

### DIFF
--- a/optaweb-employee-rostering-standalone/pom.xml
+++ b/optaweb-employee-rostering-standalone/pom.xml
@@ -175,24 +175,12 @@
                 </goals>
                 <configuration>
                   <skip>${skipITs}</skip>
-                  <executable>${container.runtime}</executable>
+                  <executable>${project.basedir}/run_cypress_tests.sh</executable>
                   <arguments>
-                    <argument>run</argument>
-                    <argument>--network=host</argument> <!-- Cypress accesses UI running on the host -->
-                    <argument>-v</argument>
-                    <argument>${project.parent.basedir}/${frontend.project.name}:/e2e:Z</argument>
-                    <argument>-w</argument>
-                    <argument>/e2e</argument>
-                    <argument>${user.flag}</argument>
-                    <argument>${user.name.group}</argument>
-                    <argument>--entrypoint</argument>
-                    <argument>cypress</argument>
-                    <argument>cypress/included:${version.cypress.docker}</argument>
-                    <argument>run</argument> <!-- Executing cypress:run -->
-                    <argument>--project</argument>
-                    <argument>.</argument>
-                    <argument>--config</argument>
-                    <argument>baseUrl=http://localhost:${application.port}</argument>
+                    <argument>${container.runtime}</argument>
+                    <argument>${maven.multiModuleProjectDirectory}${file.separator}${frontend.project.name}</argument>
+                    <argument>${version.cypress.docker}</argument>
+                    <argument>${application.port}</argument>
                   </arguments>
                 </configuration>
               </execution>
@@ -200,19 +188,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-    <id>docker</id>
-    <activation>
-      <property>
-        <name>container.runtime</name>
-        <value>docker</value>
-      </property>
-    </activation>
-    <properties>
-      <user.flag>--user</user.flag>
-      <user.name.group>1000:1000</user.name.group>
-    </properties>
     </profile>
   </profiles>
 </project>

--- a/optaweb-employee-rostering-standalone/run_cypress_tests.sh
+++ b/optaweb-employee-rostering-standalone/run_cypress_tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+readonly CONTAINER_RUNTIME=$1
+readonly FRONTEND_PROJECT_PATH=$2
+readonly VERSION_CYPRESS=$3
+readonly APPLICATION_PORT=$4
+
+user_command="--user  $(id -u):$(id -g)"
+
+if [[ "$CONTAINER_RUNTIME" == "podman" ]]
+then
+    user_command="${user_command} --userns=keep-id"
+fi
+
+$CONTAINER_RUNTIME run --network=host \
+                          -v $FRONTEND_PROJECT_PATH:/e2e:Z \
+                          $user_command \
+                          -w /e2e --entrypoint cypress docker.io/cypress/included:$VERSION_CYPRESS \
+                          run --project . --config baseUrl=http://localhost:$APPLICATION_PORT
+


### PR DESCRIPTION
After cypress tests gets executed it writes video under cypress/videos.
Jenkins uses rootfull docker by default so the videos ownership is root

The Jenkins agent fails to clean up the files since it use jenkins user instead of root.

Podman require write access to the mounted folder as well so even thought it is rootless by default it needs to have UID to write.
userns=keep-id maps host user to be the same as container user

Cherry pick of 6690d7e5