### PR TITLE
update npm to version 6.14.18

### DIFF
--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [11]
-        maven-version: ['3.8.1']
+        maven-version: ['3.8.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Full downstream build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         java-version: [11, 17]
-        maven-version: ['3.8.1']
+        maven-version: ['3.8.6']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <version.javax.activation>1.1.1</version.javax.activation>
     <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.node>v12.16.2</version.node>
-    <version.npm>6.14.4</version.npm>
+    <version.npm>6.14.18</version.npm>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
   </properties>
 


### PR DESCRIPTION
The reason to try to update npm version here is that: Indy/PNC "sidecar" uses TLS v.1.3 and projects **optaweb-employee-rostering** and **optaweb-vehicle-routing** are using an old npm version and for some reason it seems they don't work reliably. So it means that we are having to rebuild those projects on PNC until they pass.

Maybe upgrading npm to a version that was released recently could fix that.

**Related PRs:**
- https://github.com/kiegroup/optaweb-employee-rostering/pull/887
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/861
