### PR TITLE
[CVE-2022-38900][RHPAM-4663] decode-uri-component to 0.2.2

### DIFF
--- a/optaweb-employee-rostering-frontend/package-lock.json
+++ b/optaweb-employee-rostering-frontend/package-lock.json
@@ -5813,9 +5813,7 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "version": "0.2.2"
     },
     "deep-diff": {
       "version": "0.3.8",
@@ -15841,7 +15839,7 @@
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "requires": {
         "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.2.2",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"


### PR DESCRIPTION
to be backported to 8.13.x-blue
https://issues.redhat.com/browse/RHPAM-4663

- https://github.com/kiegroup/optaweb-vehicle-routing/pull/862
- https://github.com/kiegroup/optaweb-employee-rostering/pull/888